### PR TITLE
add cbapi.cache to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ cbapi-python
 from setuptools import setup
 import sys
 
-packages = ['cbapi', 'cbapi.protection', 'cbapi.response']
+packages = ['cbapi', 'cbapi.protection', 'cbapi.response', 'cbapi.cache']
 if sys.version_info < (3, 0):
     packages.extend(['cbapi.legacy', 'cbapi.legacy.util'])
 


### PR DESCRIPTION
Commit resolves issue: setup.py install not including newly added src/cbapi/cache

Package installation tested with Python 2.7.11 only.