### PR TITLE
Require query flag

### DIFF
--- a/examples/response/alert_bulk_resolve.py
+++ b/examples/response/alert_bulk_resolve.py
@@ -8,7 +8,7 @@ import time
 
 def main():
     parser = build_cli_parser("Bulk resolve alerts")
-    parser.add_argument("--query", action="store", default="",
+    parser.add_argument("--query", action="store", default="", required=True,
                         help="The query string of alerts to resolve. All matching alerts will be resolved.")
 
     args = parser.parse_args()


### PR DESCRIPTION
Just running the script without arguments should not lead to automatic resolution of all alerts, this is dangerous.
Discovery of arguments is often use of the script and --help, or -h, and in some cases running the tool without arguments. In this case if the user has a default profile set, all alerts could be set to resolved by mistake.