### PR TITLE
Fix typo in object name, used 'd' for 'defense'

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,11 +69,11 @@ As of version 1.2, cbapi now provides support for Cb Defense too!
    >>> #
    >>> # Create our Cb Defense API object
    >>> #
-   >>> p = CbDefenseAPI()
+   >>> d = CbDefenseAPI()
    >>> #
    >>> # Select any devices that have the hostname WIN-IA9NQ1GN8OI and an internal IP address of 192.168.215.150
    >>> #
-   >>> devices = c.select(Device).where('hostNameExact:WIN-IA9NQ1GN8OI').and_("ipAddress:192.168.215.150").first()
+   >>> devices = d.select(Device).where('hostNameExact:WIN-IA9NQ1GN8OI').and_("ipAddress:192.168.215.150").first()
    >>> #
    >>> # Change those devices' policy into the Windows_Restrictive_Workstation policy.
    >>> #


### PR DESCRIPTION
Noticed the object name being created was `p` and the one being called was `c`. Changed them both to `d` for "Defense".