### PR TITLE
CbTH: Minor example, API shoring

### DIFF
--- a/examples/threathunter/create_feed.py
+++ b/examples/threathunter/create_feed.py
@@ -2,11 +2,8 @@
 
 import sys
 import time
-from collections import defaultdict
-import validators
-import hashlib
 
-from cbapi.example_helpers import eprint, read_iocs, build_cli_parser, get_cb_threathunter_object
+from cbapi.example_helpers import read_iocs, build_cli_parser, get_cb_threathunter_object
 from cbapi.psc.threathunter import Feed
 
 

--- a/examples/threathunter/watchlist_operations.py
+++ b/examples/threathunter/watchlist_operations.py
@@ -141,7 +141,7 @@ def create_watchlist(cb, parser, args):
     report_dict["iocs"] = iocs
 
     report = cb.create(Report, report_dict)
-    report.save()
+    report.save_watchlist()
 
     watchlist_dict["report_ids"].append(report.id)
     watchlist = cb.create(Watchlist, watchlist_dict)
@@ -230,7 +230,7 @@ def import_watchlist(cb, parser, args):
                 [ioc_id.update(value.encode("utf-8")) for value in ioc["values"]]
                 ioc["id"] = ioc_id.hexdigest()
         report = cb.create(Report, rep_dict)
-        report.save()
+        report.save_watchlist()
         report_ids.append(report.id)
 
     # finally, update our new watchlist with the imported reports

--- a/examples/threathunter/watchlist_operations.py
+++ b/examples/threathunter/watchlist_operations.py
@@ -9,8 +9,6 @@ import logging
 import json
 import time
 import hashlib
-import validators
-from collections import defaultdict
 
 log = logging.getLogger(__name__)
 

--- a/src/cbapi/psc/threathunter/models.py
+++ b/src/cbapi/psc/threathunter/models.py
@@ -355,7 +355,7 @@ class Report(FeedModel):
         if self.iocs_v2:
             self._iocs_v2 = [IOC_V2(cb, initial_data=ioc, report_id=self.id) for ioc in self.iocs_v2]
 
-    def save(self):
+    def save_watchlist(self):
         """Saves this report *as a watchlist report*.
 
         .. NOTE::


### PR DESCRIPTION
Removes some unused imports after review on #133, changes `Report.save()` to `Report.save_watchlist()` to emphasize that there is no direct `save` method for Feed reports.

cc @jgarman 