### PR TITLE
Removing refs to VT alliance feeds

### DIFF
--- a/src/cbapi/response/models.py
+++ b/src/cbapi/response/models.py
@@ -1531,15 +1531,6 @@ class ProcessQuery(WatchlistEnabledQuery):
 @immutable
 class Binary(TaggedModel):
 
-    class VirusTotal(namedtuple('VirusTotal', 'score link')):
-        """
-        Class containing information associated with a Virus Total Score
-
-        :param int score: Virus Total score
-        :param str link: Virus Total link for this md5
-        """
-        pass
-
     class SigningData(namedtuple('SigningData', 'result publisher issuer subject sign_time program_name')):
         """
         Class containing binary signing information
@@ -1787,17 +1778,6 @@ class Binary(TaggedModel):
         """
         return self._attribute('is_executable_image', False)
 
-    @property
-    def virustotal(self):
-        """
-        Returns a :class:`.VirusTotal` object containing detailed Virus Total information about this binary.
-        """
-        virustotal_score = self._attribute('alliance_score_virustotal', 0)
-        if virustotal_score:
-            ret = Binary.VirusTotal._make([int(virustotal_score), self._attribute('alliance_link_virustotal', "")])
-        else:
-            ret = Binary.VirusTotal._make([0, ''])
-        return ret
 
     @property
     def icon(self):

--- a/src/cbapi/response/models/binary.yaml
+++ b/src/cbapi/response/models/binary.yaml
@@ -1,6 +1,5 @@
 type: object
 required:
-  - alliance_score_virustotal
   - company_name
   - copied_mod_len
   - digsig_issuer
@@ -68,9 +67,6 @@ properties:
   company_name:
     type: string
     description: 'If present, Company name from [FileVersionInformation](http://msdn.microsoft.com/en-us/library/system.diagnostics.fileversioninfo.aspx)'
-  alliance_score_virustotal:
-    type: string
-    description: 'If enabled and the hit count > 1, the number of [VirusTotal](http://virustotal.com) hits for this md5'
   server_added_timestamp:
     type: string
     format: iso-date-time


### PR DESCRIPTION
Customers should now use cb-virustotal-connector available on yum and this github org, to be perfectly square 