### PR TITLE
Updated import link to proper module

### DIFF
--- a/examples/defense/list_events.py
+++ b/examples/defense/list_events.py
@@ -12,7 +12,7 @@
 import sys
 import re
 from datetime import datetime
-from cbapi.defense.models import Event
+from cbapi.psc.defense.models import Event
 from cbapi.example_helpers import build_cli_parser, get_cb_defense_object
 
 


### PR DESCRIPTION
`list_events.py` under `examples/defense` had a improper module call. `from cbapi.defense.models import Event` that needed to be changed to `from cbapi.psc.defense.models import Event`.