### PR TITLE
Update to support 6.3 changes

### DIFF
--- a/src/cbapi/response/cblr.py
+++ b/src/cbapi/response/cblr.py
@@ -14,7 +14,7 @@ class LiveResponseSessionManager(CbLRManagerBase):
     cblr_session_cls = LiveResponseSession
 
     def _get_or_create_session(self, sensor_id):
-        sensor_sessions = [s for s in self._cb.get_object("{cblr_base}/session".format(cblr_base=self.cblr_base))
+        sensor_sessions = [s for s in self._cb.get_object("{cblr_base}/session?active_only=true".format(cblr_base=self.cblr_base))
                            if s["sensor_id"] == sensor_id and s["status"] in ("pending", "active")]
 
         if len(sensor_sessions) > 0:


### PR DESCRIPTION
The CBR 6.3 release came with the following update which was not implemented in the CBAPI.
 
New to CB Response 6.3:
To view all active CB live response sessions, use a GET command with the parameter ?active_only=true to https://<hostname>/api/v1/cblr/session. The following request will retrieve a list of currently active sessions. This feature was added to reduce the size of the response when there are a large number of closed sessions. Note: If you just created a session, it might show up as status: pending, this will transition to status: active once the session is ready.