### PR TITLE
Change Alert model object to use v2 route

### DIFF
--- a/src/cbapi/response/models.py
+++ b/src/cbapi/response/models.py
@@ -271,7 +271,7 @@ class AlertQuery(Query):
 
 
 class Alert(MutableBaseModel):
-    urlobject = "/api/v1/alert"
+    urlobject = "/api/v2/alert"
     swagger_meta_file = "response/models/alert.yaml"
     _change_object_http_method = "POST"
     primary_key = "unique_id"


### PR DESCRIPTION
The original `/api/v1/alert` route includes expensive-to-compute data in the response. Switch to using `v2` route to make the Alert model object more performant.