### PR TITLE
Cb ThreatHunter models.py replace_reports and append_reports fixes

### DIFF
--- a/src/cbapi/psc/threathunter/models.py
+++ b/src/cbapi/psc/threathunter/models.py
@@ -304,7 +304,7 @@ class Feed(FeedModel):
         rep_dicts = [report._info for report in reports]
         body = {"reports": rep_dicts}
 
-        self._cb.post_object("/threathunter/feedmgr/v1/{}/report".format(self.id), body)
+        self._cb.post_object("/threathunter/feedmgr/v1/feed/{}/report".format(self.id), body)
 
     def append_reports(self, reports):
         """Append the given reports to this feed's current reports.
@@ -317,10 +317,10 @@ class Feed(FeedModel):
             raise InvalidObjectError("missing feed ID")
 
         rep_dicts = [report._info for report in reports]
-        rep_dicts += [report._info for report in self._reports]
+        rep_dicts += [report._info for report in self.reports]
         body = {"reports": rep_dicts}
 
-        self._cb.post_object("/threathunter/feedmgr/v1/{}/report".format(self.id), body)
+        self._cb.post_object("/threathunter/feedmgr/v1/feed/{}/report".format(self.id), body)
 
 
 class Report(FeedModel):


### PR DESCRIPTION
I would like to propose 2 fixes to the Cb ThreatHunter `models.py` code, more specifically in the `replace_reports` and `append_reports` functions.

## Incorrect feedmgr API endpoints

The first issue is that the API endpoints for replacing and appending reports to a feed appear to be incorrect. The code uses `/threathunter/feedmgr/v1/{}/report` on lines 307 and 323 but according to https://developer.carbonblack.com/reference/cb-threathunter/legacy/feed-api/ this should be `/threathunter/feedmgr/v1/feed/(feed_id)/report` instead (adding in the missing 'feed' portion). The current API endpoints result in a 404 error.

## Empty self._reports in feed objects

The second issue I came across was that `append_reports` does not append but overwrites (or replaces) the feed reports. In my testing the issue appears to be with the existing set of reports in the feeds which are retrieved via `self._reports`. That variable remains empty in some cases. When executing the below code example the feed `__init__` function ends up at line 204 and just sets `item = initial_data` and `reports` remains an empty list (even though calling `feed.reports` after the feed object is retrieved does return the actual reports. 

The end result is that `append_reports` combines an empty `self._reports` with a new set of reports, effectively replacing all reports instead of appending the new reports.

Sample code:
```Python
cb = CbThreatHunterAPI()
feed_name = "Name of an existing feed"
feeds = [feed for feed in cb.select(Feed).where(include_public=False) if feed.name == feed_name]
feed = feeds[0]
feed_reports = feed.reports

# load list of report dicts from JSON file
with open('reports_file.json') as json_file:  
    imp_reports = json.load(json_file)

# Iterate over imported reports, add if new, replace if it exists
for imp_report in imp_reports:
    existing_report = next((report for report in feed_reports if imp_report["id"] == report.id), None)

    if existing_report:
        # replace the report (works as intended)
        existing_report.update(**imp_report)
    else:
        # add the report (does not work as intended)
        tmp = cb.create(Report, imp_report)
        # The current models.py code will replace all reports with [tmp]
        feed.append_reports([tmp])
```

To fix, I replaced the call to the variable `self._reports` on line 320 with a call to the `self.reports` function instead which builds the reports dynamically using `return self._cb.select(Report).where(feed_id=self.id)` instead of relying on the internal variable `self._reports` which might or might not contain reports.