### PR TITLE
Use `yaml.safe_load`

### DIFF
--- a/src/cbapi/models.py
+++ b/src/cbapi/models.py
@@ -35,7 +35,7 @@ class CbMetaModel(type):
         swagger_meta_file = clsdict.pop("swagger_meta_file", None)
         model_data = {}
         if swagger_meta_file:
-            model_data = yaml.load(
+            model_data = yaml.safe_load(
                 open(os.path.join(mcs.model_base_directory, swagger_meta_file), 'rb').read())
 
         clsdict["__doc__"] = "Represents a %s object in the Carbon Black server.\n\n" % (name,)


### PR DESCRIPTION
Fix #151 by using `yaml.safe_load` when loading the model YAML files