### PR TITLE
Require the API token up front during `cbapi-response configure`

### DIFF
--- a/bin/cbapi-response
+++ b/bin/cbapi-response
@@ -65,21 +65,10 @@ def configure(opts):
     else:
         ssl_verify = False
 
-    token = input("API token (if unknown, leave blank): ")
+    token = input("API token: ")
     if not token:
-        print("No API token provided: we will look it up using your username & password")
-        username = input("Username: ")
-        password = getpass.getpass("Password: ")
-
-        print("Retrieving API token for {0}...".format(username))
-
-        try:
-            token = get_api_token(url, username, password, verify=ssl_verify)
-        except Exception as e:
-            import traceback
-            traceback.print_exc()
-            print("Could not retrieve API token: {0}".format(str(e)))
-            return 1
+        print("Please obtain your API token from the profile page after logging into the CBR console.")
+        return 1
 
     config = RawConfigParser()
     config.readfp(StringIO('[default]'))

--- a/bin/cbapi-response
+++ b/bin/cbapi-response
@@ -14,7 +14,6 @@ if six.PY3:
 else:
     from cStringIO import StringIO
 
-from cbapi.response.rest_api import get_api_token
 from cbapi.six.moves.configparser import RawConfigParser
 from cbapi.connection import check_python_tls_compatibility
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -264,7 +264,6 @@ is called. Let's call ``.save()`` and modify one of the Model Object's propertie
      Last refreshed at Mon Nov  7 16:54:00 2016
     -------------------------------------------------------------------------------
 
-                  auth_token: 8b2dcf9d59b7da1a0b2b4ec50a77d8ca3d7dcb9c
                        email: jgarman@carbonblack.com
     (*)           first_name: J
                 global_admin: False

--- a/examples/response/user_operations.py
+++ b/examples/response/user_operations.py
@@ -105,17 +105,6 @@ def add_user(cb, parser, args):
         print("Added user {0}.".format(u.username))
 
 
-def get_api_key(cb, parser, args):
-    if not args.password:
-        password = getpass.getpass("Password for {0}: ".format(args.username))
-    else:
-        password = args.password
-
-    print("API token for user {0}: {1}".format(args.username, get_api_token(cb.credentials.url,
-                                                                            args.username, password,
-                                                                            verify=cb.credentials.ssl_verify)))
-
-
 def delete_user(cb, parser, args):
     user = cb.select(User, args.username)
     try:
@@ -167,8 +156,6 @@ def main():
         return list_users(cb, parser, args)
     elif args.command_name == "list-teams":
         return list_teams(cb, parser, args)
-    elif args.command_name == "get-api-key":
-        return get_api_key(cb, parser, args)
     elif args.command_name == "add":
         return add_user(cb, parser, args)
     elif args.command_name == "add-team":

--- a/examples/response/user_operations.py
+++ b/examples/response/user_operations.py
@@ -7,7 +7,6 @@ from cbapi.example_helpers import build_cli_parser, get_cb_response_object, get_
 from cbapi.errors import ServerError
 import logging
 import getpass
-from cbapi.response.rest_api import get_api_token
 
 
 log = logging.getLogger(__name__)

--- a/src/cbapi/response/rest_api.py
+++ b/src/cbapi/response/rest_api.py
@@ -8,45 +8,12 @@ from distutils.version import LooseVersion
 from ..connection import BaseAPI
 from .models import Process, Binary, Watchlist, Investigation, Alert, ThreatReport, StoragePartition
 from ..errors import UnauthorizedError, ApiError
-from ..errors import CredentialError
 from .cblr import LiveResponseSessionManager
 from .query import Query
 
-import requests
 
 import logging
 log = logging.getLogger(__name__)
-
-
-def get_api_token(base_url, username, password, **kwargs):
-    """Retrieve the API token for a user given the URL of the server, username, and password.
-
-    Scripts should use API tokens wherever possible. Use of this function now requires EnableRetrieveToken=True to be
-    set in cb.conf.
-
-    :param str base_url: The URL of the server (for example, ``https://carbonblack.server.com``)
-    :param str username: The user's username
-    :param str password: The user's password
-    :param bool verify: (optional) When set to False, turn off SSL certificate verification
-
-    :return: The user's API token
-    :rtype: str
-    :raises ApiError: if there is an error parsing the reply
-    :raises CredentialError: if the username/password is incorrect
-    """
-    r = requests.post("{0:s}/api/auth/retrieve-token".format(base_url),
-                     json={"username": username, "password": password}, **kwargs)
-    if r.status_code == 406:
-        raise CredentialError(message="Please log in to the CBR console, then try again")
-    elif r.status_code == 404:
-        raise CredentialError(message="Please set EnableRetrieveToken=True in cb.conf and restart services")
-    elif r.status_code >= 300:
-        raise CredentialError(message="Invalid credentials: {0:s}".format(r.text))
-
-    try:
-        return r.json()["auth_token"]
-    except:
-        raise ApiError(message="Error retrieving auth_token: {0:s}".format(r.text))
 
 
 class CbResponseAPI(BaseAPI):


### PR DESCRIPTION
Upcoming changes to authentication in the product require the user to obtain their API token directly from their user profile page.

This PR removes the ability to obtain the token during `cbapi-response configure` given a username and password.