### PR TITLE
Fixed function overwrite in Process Query

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ install_requires=[
     'pika',
     'prompt_toolkit',
     'pygments',
-    'pytest',
+    'pytest<=5.0',
     'python-dateutil',
     'protobuf',
     'solrq',
-    'validators',
+    'validators'
 ]
 
 if sys.version_info < (2, 7):

--- a/src/cbapi/response/models.py
+++ b/src/cbapi/response/models.py
@@ -1384,7 +1384,7 @@ class WatchlistEnabledQuery(Query):
 class ProcessQuery(WatchlistEnabledQuery):
     def __init__(self, doc_class, cb, query=None, raw_query=None):
         super(ProcessQuery, self).__init__(doc_class, cb, query, raw_query)
-
+        self.num_children = 15
         if cb._has_legacy_partitions:
             self._default_args["cb.legacy_5x_mode"] = True
 
@@ -1424,12 +1424,12 @@ class ProcessQuery(WatchlistEnabledQuery):
         except ValueError:
             num_children = 15
 
-        nq.max_children = num_children
+        nq.num_children = num_children
         return nq
 
     def _perform_query(self, start=0, numrows=0):
         for item in self._search(start=start, rows=numrows):
-            yield self._doc_class.new_object(self._cb, item, self.max_children)
+            yield self._doc_class.new_object(self._cb, item, self.num_children)
 
     def set_legacy_mode(self, new_value=True):
         self._default_args["cb.legacy_5x_mode"] = new_value


### PR DESCRIPTION
The max_children function was being passed to the Process model in python2 which caused an invalid construction of the URL.

This was reported in EA-15158