### PR TITLE
Fixing bug where max_children is not passed to walk_children

### DIFF
--- a/src/cbapi/response/models.py
+++ b/src/cbapi/response/models.py
@@ -2579,7 +2579,8 @@ class Process(TaggedModel):
                                            "terminated": False
                                        },
                                        is_suppressed=child.get("is_suppressed", False),
-                                       proc_data=child)
+                                       proc_data=child,
+                                       max_children=self.max_children)
         else:
             for cp in self.childprocs:
                 yield cp
@@ -3154,8 +3155,9 @@ class CbNetConnEvent(CbEvent):
 
 
 class CbChildProcEvent(CbEvent):
-    def __init__(self, parent_process, timestamp, sequence, event_data, is_suppressed=False, proc_data=None):
+    def __init__(self, parent_process, timestamp, sequence, event_data, is_suppressed=False, proc_data=None, max_children=15):
         super(CbChildProcEvent, self).__init__(parent_process, timestamp, sequence, event_data)
+        self.max_children = max_children
         self.event_type = u'Cb Child Process event'
         self.stat_titles.extend(['procguid', 'pid', 'path', 'md5'])
         self.is_suppressed = is_suppressed
@@ -3197,7 +3199,7 @@ class CbChildProcEvent(CbEvent):
             child_unique_id = self.procguid
 
         return self.parent._cb.select(Process, child_unique_id, initial_data=proc_data,
-                                      suppressed_process=self.is_suppressed)
+                                      suppressed_process=self.is_suppressed, max_children=self.max_children)
 
 
 class CbCrossProcEvent(CbEvent):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code).
- [x] Linter has passed locally and any fixes were made for failures.
- [x] A self-review of the code has been done.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [ ] Other (please describe):


## What is the ticket or issue number?
<!-- Please link to a jira ticket or relevant issue. -->

- Ticket Number: N/A

- Issue Number: #211 

## Pull Request Description
This passes the max_children flag to walk_children so that subsequent requests that walk_children does carries the max_children flag that was set.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## How Has This Been Tested?

Run the walk_children.py example script with --verbose to make sure that `?children=x` is set correctly in all API calls.

## Other information:

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
