### PR TITLE
Account for sensor queue depth when scheduling jobs

### DIFF
--- a/src/cbapi/live_response_api.py
+++ b/src/cbapi/live_response_api.py
@@ -797,7 +797,9 @@ class LiveResponseJobScheduler(threading.Thread):
         sensors = [s for s in self._cb.select(Sensor) if s.id in self._unscheduled_jobs
                    and s.id not in self._job_workers
                    and s.status == "Online"]
-        sensors_to_schedule = sorted(sensors, key=lambda x: x.next_checkin_time)[:schedule_max]
+        sensors_to_schedule = sorted(sensors, key=lambda x: (
+            int(x.num_storefiles_bytes) + int(x.num_eventlog_bytes), x.next_checkin_time
+            ))[:schedule_max]
 
         log.debug("Spawning new workers to handle these sensors: {0}".format(sensors_to_schedule))
         for sensor in sensors_to_schedule:


### PR DESCRIPTION

## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [X] New and existing tests pass locally with the changes.
- [X] Code follows the style guidelines of this project (PEP8, clean code).
- [X] Linter has passed locally and any fixes were made for failures.
- [X] A self-review of the code has been done.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [X] Other (please describe): processing speed improvement


## Pull Request Description

Changes the sort for adding new jobs from next check-in time to: (total sensor queue length, next check-in time).

When processing a series of live response sessions against a very large number of sensors, I have found that large sensor binary and event queues tend to slow things down considerably. This small tweak to the sort logic in the job scheduler has improved processing considerably for jobs with thousands of sensors. It prioritizes sensors with the shortest job queues first for processing. This allows sensors with a backlog more time to drain without blocking the rest of the operation.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?

I have run this on long job submissions (8000+ sensors, running a series Live Response commands against all of them). It has improved the speed of processing the work.

## Other information:

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
