### PR TITLE
Update to v2 based process and event searches

### DIFF
--- a/src/cbapi/psc/threathunter/models.py
+++ b/src/cbapi/psc/threathunter/models.py
@@ -20,7 +20,7 @@ class Process(UnrefreshableModel):
     """
     default_sort = 'last_update desc'
     primary_key = "process_guid"
-    validation_url = "/threathunter/search/v1/orgs/{}/processes/search_validation"
+    validation_url = "/api/investigate/v1/orgs/{}/processes/search_validation"
 
     class Summary(UnrefreshableModel):
         """Represents a summary of organization-specific information for
@@ -28,7 +28,7 @@ class Process(UnrefreshableModel):
         """
         default_sort = "last_update desc"
         primary_key = "process_guid"
-        urlobject_single = "/threathunter/search/v1/orgs/{}/processes/summary"
+        urlobject_single = "/api/investigate/v1/orgs/{}/processes/summary"
 
         def __init__(self, cb, model_unique_id):
             url = self.urlobject_single.format(cb.credentials.org_key)
@@ -171,8 +171,8 @@ class Event(UnrefreshableModel):
     """Events can be queried for via ``CbThreatHunterAPI.select``
     or though an already selected process with ``Process.events()``.
     """
-    urlobject = '/threathunter/search/v1/orgs/{}/events/_search'
-    validation_url = '/threathunter/search/v1/orgs/{}/events/search_validation'
+    urlobject = '/api/investigate/v2/orgs/{}/events/{}/_search'
+    validation_url = '/api/investigate/v1/orgs/{}/events/search_validation'
     default_sort = 'last_update desc'
     primary_key = "process_guid"
 
@@ -180,7 +180,7 @@ class Event(UnrefreshableModel):
     def _query_implementation(cls, cb):
         return Query(cls, cb)
 
-    def __init__(self, cb,  model_unique_id=None, initial_data=None, force_init=False, full_doc=True):
+    def __init__(self, cb, model_unique_id=None, initial_data=None, force_init=False, full_doc=True):
         super(Event, self).__init__(cb, model_unique_id=model_unique_id, initial_data=initial_data,
                                     force_init=force_init, full_doc=full_doc)
 
@@ -197,8 +197,10 @@ class Tree(UnrefreshableModel):
         return TreeQuery(cls, cb)
 
     def __init__(self, cb, model_unique_id=None, initial_data=None, force_init=False, full_doc=True):
-        super(Tree, self).__init__(cb, model_unique_id=model_unique_id, initial_data=initial_data,
-                                   force_init=force_init, full_doc=full_doc)
+        super(Tree, self).__init__(
+            cb, model_unique_id=model_unique_id, initial_data=initial_data,
+            force_init=force_init, full_doc=full_doc
+        )
 
     @property
     def children(self):

--- a/src/cbapi/psc/threathunter/query.py
+++ b/src/cbapi/psc/threathunter/query.py
@@ -295,7 +295,7 @@ class Query(PaginatedQuery):
             return
 
         url = self._doc_class.validation_url.format(self._cb.credentials.org_key)
-        validated = self._cb.get_object(url, query_parameters=args)
+        validated = self._cb.get_object(url, query_parameters={'q': args['query']})
 
         if not validated.get("valid"):
             raise ApiError("Invalid query: {}: {}".format(args, validated["invalid_message"]))
@@ -303,13 +303,13 @@ class Query(PaginatedQuery):
     def _search(self, start=0, rows=0):
         # iterate over total result set, 100 at a time
         args = self._get_query_parameters()
-        #self._validate(args)
+        self._validate(args)
 
         if start != 0:
             args['start'] = start
         args['rows'] = self._batch_size
 
-        #args = {"search_params": args}
+        # args = {"search_params": args}
 
         current = start
         numrows = 0
@@ -400,7 +400,7 @@ class AsyncProcessQuery(Query):
             raise ApiError("Query already submitted: token {0}".format(self._query_token))
 
         args = self._get_query_parameters()
-        #self._validate(args)
+        self._validate(args)
 
         url = "/api/investigate/v2/orgs/{}/processes/search_jobs".format(self._cb.credentials.org_key)
         query_start = self._cb.post_object(url, body=args)

--- a/src/cbapi/psc/threathunter/query.py
+++ b/src/cbapi/psc/threathunter/query.py
@@ -295,7 +295,11 @@ class Query(PaginatedQuery):
             return
 
         url = self._doc_class.validation_url.format(self._cb.credentials.org_key)
-        validated = self._cb.get_object(url, query_parameters={'q': args['query']})
+
+        if args.get('query', False):
+            args['q'] = args['query']
+
+        validated = self._cb.get_object(url, query_parameters=args)
 
         if not validated.get("valid"):
             raise ApiError("Invalid query: {}: {}".format(args, validated["invalid_message"]))


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code).
- [x] Linter has passed locally and any fixes were made for failures.
- [x] A self-review of the code has been done.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [ ] Other (please describe):


## What is the ticket or issue number?

No ticket number available.

## Pull Request Description

This pull request updates Cb ThreatHunter process and event searches to use the new v2 style API. Tests (see below) indicate that process search results now contain aggregated lists of TTP and enriched_event_type data. We are also able to retrieve more or even all events for a particular Process object (versus only a handful of events with the v1 event search API). Retrieval of event data now correctly uses batches of 100 events per iteration and it will loop until the value of `num_available` has been reached (fixing the issues reported in https://github.com/carbonblack/cbapi-python/issues/239).

## Does this introduce a breaking change?

- [x] Yes (maybe? see below)
- [ ] No

As the change from Process Search v1 to v2 splits out enriched Process search results from the regular process search results (and moves these solely to the enriched_event search) this PR will result in procecss search results not including enriched events. An additional update will be required to support explicitly searching for enriched process events. Retrieving events from a process GUID are not affected by this and function the same as before.

~Validation for event and process searches had to be disabled as the v2 search API does not supply a validation endpoint and the query parameter json format changed between v1 and v2. As a result the v1 validation API endpoints can not be used anymore. Any lines in `query.py` where `_validate()` is called have been commented out and the `_validate()` has been left in place.~ (see 'Update 2' below)

**Update 1**: It also still uses the v1 process search status API endpoint (`/api/investigate/v1/orgs/{org_key}/processes/search_jobs/{query_id}`) as v2 does not provide that functionality yet (it only has `/api/investigate/v2/orgs/{org_key}/processes/search_jobs/{job_id}/results`). However, using a v2 job-id with the v1 status endpoint returns the contacted vs completed information as expected. If this is not desired, then the v2 process search results endpoint (`/api/investigate/v2/orgs/{org_key}/processes/search_jobs/{job_id}/results`) can be used instead. It will simply return the first set of results for each status check instead of just search completion status (i.e. only the counts of the search nodes that were contacted and have returned results).

**Update 2**: the `validate()` function calls have been enabled again and the `validate()` function was updated to send  the query as a `q` parameter instead of the now default `query` argument used in the v2 search API.

## How Has This Been Tested?

The following script was used to test the changes:

```Python
from cbapi.psc.threathunter import CbThreatHunterAPI
from cbapi.psc.threathunter.models import Event, Process

cb = CbThreatHunterAPI(profile='redlab2')
guid = 'ORGKEY-01319b03-00000cc4-00000000-1d64c634925f39c'

# Process search test
query_result = cb.select(Process).where(process_guid=guid)

for process in query_result:
    print(process)

# Event search test
query_result = cb.select(Event).where(process_guid=guid).and_(event_type="childproc")

for event in query_result:
    print(event)
```

The below alternative code works as well (using the `events()` function on a Process object):

```python
from cbapi.psc.threathunter import CbThreatHunterAPI
from cbapi.psc.threathunter.models import Event, Process

cb = CbThreatHunterAPI(profile='redlab2')
guid = 'N5DFVQXD-01319b03-00000cc4-00000000-1d64c634925f39c'

query_result = cb.select(Process).where(process_guid=guid)

for process in query_result:
    print(process)

    for event in process.events(event_type='childproc'):
        print(event)
```

Either of these test scripts results in the below output:

```
❯ python test.py
Process object, bound to https://defense-prod05.conferdeploy.net.
-------------------------------------------------------------------------------

       backend_timestamp: 2020-07-03T12:27:16.961Z
         childproc_count: 11
         crossproc_count: 7550
      device_external_ip: REDACTED
               device_id: 20028163
      device_internal_ip: REDACTED
             device_name: redlab-win10-2
               device_os: WINDOWS
        device_policy_id: 100934
        device_timestamp: 2020-07-03T12:25:45.297Z
                enriched: True
     enriched_event_type: ['CREATE_PROCESS', 'FILE_CREATE', 'REGISTRY_ACC...
              event_type: ['childproc', 'crossproc', 'filemod', 'regmod']
           filemod_count: 616
            ingress_time: 1593779216128
                  legacy: True
           modload_count: 107
           netconn_count: 0
                  org_id: ORGKEY
             parent_guid: ORGKEY-01319b03-000002b4-00000000-1d64c60d26a...
             parent_hash: ['41e785ff78c698c860be93f6f1f0a2369f8932d186d7d...
              parent_pid: 692
    process_effective_reputation: TRUSTED_WHITE_LIST
            process_guid: ORGKEY-01319b03-00000cc4-00000000-1d64c634925...
            process_hash: ['0308289d3bd5c9476bcfb96acf530343', '0a8fb7ed0...
            process_name: c:\programdata\microsoft\windows defender\platf...
             process_pid: [3268]
      process_reputation: TRUSTED_WHITE_LIST
        process_username: ['NT AUTHORITY\\SYSTEM']
            regmod_count: 401
        scriptload_count: 0
                     ttp: ['ENUMERATE_PROCESSES', 'MITRE_T1003_CREDENTIAL...
           watchlist_hit: ['wJVUBB44RdmWs2w4IexFxQ:ENRn6bsERDytLA1fk8GjzQ...
Event object, bound to https://defense-prod05.conferdeploy.net.
-------------------------------------------------------------------------------

       backend_timestamp: 2020-07-03T09:26:59.326Z
       childproc_cmdline: "C:\ProgramData\Microsoft\Windows Defender\plat...
    childproc_effective_reputation: REP_WHITE
           childproc_md5: c9ecd001c9c6d38837dab6d16b79143b
          childproc_name: c:\programdata\microsoft\windows defender\platf...
    childproc_process_guid: ORGKEY-01319b03-00000770-00000000-1d6511bbc38...
        childproc_sha256: 5bb7a21fc68c78218b713999bd478580a1a9efcc4846f1a...
      childproc_username: NT AUTHORITY\SYSTEM
       created_timestamp: 2020-07-03T12:30:49.774Z
              event_guid: aedGYDbRSb6olNQm1uWQDw
              event_hash: 7cc4809e83ebed0a6f174474669fd9af
         event_timestamp: 2020-07-03T09:24:26.975Z
              event_type: childproc
                  legacy: False
            process_guid: ORGKEY-01319b03-00000cc4-00000000-1d64c634925...
             process_pid: 3268
Event object, bound to https://defense-prod05.conferdeploy.net.
-------------------------------------------------------------------------------

       backend_timestamp: 2020-07-03T09:26:59.326Z
       childproc_cmdline: "C:\ProgramData\Microsoft\Windows Defender\plat...
    childproc_effective_reputation: REP_WHITE
           childproc_md5: c9ecd001c9c6d38837dab6d16b79143b
          childproc_name: c:\programdata\microsoft\windows defender\platf...
    childproc_process_guid: ORGKEY-01319b03-0000134c-00000000-1d6511bbc3d...
        childproc_sha256: 5bb7a21fc68c78218b713999bd478580a1a9efcc4846f1a...
      childproc_username: NT AUTHORITY\SYSTEM
       created_timestamp: 2020-07-03T12:30:49.774Z
              event_guid: uEcQi43oSpau7HMvDXKmyA
              event_hash: f00b3364df8706fb5962020bc25bee43
         event_timestamp: 2020-07-03T09:24:27.022Z
              event_type: childproc
                  legacy: False
            process_guid: ORGKEY-01319b03-00000cc4-00000000-1d64c634925...
             process_pid: 3268
...
```