### PR TITLE
Add missing __len__() implementation for IterableQueryMixin to fix len() on Alert query

### DIFF
--- a/src/cbapi/psc/alerts_query.py
+++ b/src/cbapi/psc/alerts_query.py
@@ -24,6 +24,8 @@ class BaseAlertSearchQuery(PSCQueryBase, QueryBuilderSupportMixin, IterableQuery
         self._time_filter = {}
         self._sortcriteria = {}
         self._bulkupdate_url = "/appservices/v6/orgs/{0}/alerts/workflow/_criteria"
+        self._count_valid = False
+        self._total_results = 0
 
     def _update_criteria(self, key, newlist):
         """

--- a/src/cbapi/psc/base_query.py
+++ b/src/cbapi/psc/base_query.py
@@ -261,7 +261,7 @@ class IterableQueryMixin:
         return res[0]
 
     def __len__(self):
-        return 0
+        return self._count()
 
     def __getitem__(self, item):
         return None


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code).
- [x] Linter has passed locally and any fixes were made for failures.
- [x] A self-review of the code has been done.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [ ] Other (please describe):


## What is the ticket or issue number?
<!-- Please link to a jira ticket or relevant issue. -->

- Ticket Number: N/A
- Issue Number: N/A

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->

Requesting the length of a `BaseAlert` query always returns 0. This is because the `_count()` function in `BaseAlertSearchQuery` is never called. `__len__()` in the `IterableQueryMixin` class it inherits from is not implemented and always returns a length of 0, causing this behavior.

This PR provides a fix by updating the `__len__()` function in `IterableQueryMixin` to call the `_count()` function. It also initializes `self._count_valid` and `self._total_results` in `BaseAlertSearchQuery` with default values (as `self._count_valid` is checked by `_count()` prior to making an API call for an initial count).

Looking at the implementation for `_count()` and `__len__()` for `Query` in `cbapi/psc/threathunter/query.py` and `PaginatedQuery` in `cbapi/query.py` the default values there are set in the `PaginatedQuery` class. For this fix I've initialized the variables in `BaseAlertSearchQuery` instead and not the `IterableQueryMixin` class it inherits from. If this needs to be changed (i.e. initialization moved to `IterableQueryMixin`), please let me know.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

The following script has been used to test this PR:

```python
from cbapi.psc import CbPSCBaseAPI
from cbapi.psc.models import BaseAlert
from datetime import datetime, time

cbth = CbPSCBaseAPI(profile='profile-name')
alerts1 = cbth.select(BaseAlert).where('alert_id:ZG5U3VVQ')
alerts2 = cbth.select(BaseAlert)

print(f'Results: {len(alerts1)}')
print(f'Results: {len(alerts2)}')
```

Which results in the following output:

```shell
❯ python test2.py
Results: 1
Results: 581353
```
