### PR TITLE
[PR#237] Properly populate urlobject with ORG KEY value in _count() function

### DIFF
--- a/src/cbapi/psc/threathunter/query.py
+++ b/src/cbapi/psc/threathunter/query.py
@@ -267,7 +267,8 @@ class Query(PaginatedQuery):
 
         log.debug("args: {}".format(str(args)))
 
-        self._total_results = int(self._cb.post_object(self._doc_class.urlobject, body=args)
+        self._total_results = int(self._cb.post_object(self._doc_class.urlobject.format(self._cb_credentials.org_key),
+                                                       body=args)
                                   .json().get("response_header", {}).get("num_available", 0))
         self._count_valid = True
         return self._total_results
@@ -533,7 +534,7 @@ class TreeQuery(BaseQuery):
         results = self._cb.get_object(url, query_parameters=self._args)
 
         while results["incomplete_results"]:
-            result = self._cb.get_object(self._doc_class.urlobject, query_parameters=self._args)
+            result = self._cb.get_object(url, query_parameters=self._args)
             results["nodes"]["children"].extend(result["nodes"]["children"])
             results["incomplete_results"] = result["incomplete_results"]
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code).
- [x] Linter has passed locally and any fixes were made for failures.
- [x] A self-review of the code has been done.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [ ] Other (please describe):


## What is the ticket or issue number?
<!-- Please link to a jira ticket or relevant issue. -->

- Ticket Number: https://jira.carbonblack.local/browse/CBAPI-1736

- Issue Number: N/A

- Original Pull Request #237 

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
_(From original pull request)_

using .len() on ThreatHunter Event query objects throws a 403 error because the _count() function in cbapi/psc/threathunter/query.py does not populate self._doc_class.urlobject with an ORG KEY value (i.e. self._cb.credentials.org_key). This fix adds the required .format() function that inserts the ORG KEY into the urlobject.

A similar fix was added for the _perform_query() function where the url variable is assigned a properly populated urlobject value (which includes the ORG KEY value), but is then not used in the get_object() function that follows it.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Original test information in PR #237

## Other information:

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
This had to be implemented as a new PR because the original PR bumped the CBAPI version number, a change we don't want to make until all PR changes are settled.