### PR TITLE
Change default v2 process search request rows value to 10000

### DIFF
--- a/src/cbapi/psc/threathunter/query.py
+++ b/src/cbapi/psc/threathunter/query.py
@@ -415,6 +415,7 @@ class AsyncProcessQuery(Query):
             raise ApiError("Query already submitted: token {0}".format(self._query_token))
 
         args = self._get_query_parameters()
+        args['rows'] = 10000
         self._validate(args)
 
         url = "/api/investigate/v2/orgs/{}/processes/search_jobs".format(self._cb.credentials.org_key)
@@ -469,7 +470,7 @@ class AsyncProcessQuery(Query):
 
         return self._total_results
 
-    def _search(self, start=0, rows=10000):
+    def _search(self, start=0, rows=0):
         if not self._query_token:
             self._submit()
 

--- a/src/cbapi/psc/threathunter/query.py
+++ b/src/cbapi/psc/threathunter/query.py
@@ -469,7 +469,7 @@ class AsyncProcessQuery(Query):
 
         return self._total_results
 
-    def _search(self, start=0, rows=0):
+    def _search(self, start=0, rows=10000):
         if not self._query_token:
             self._submit()
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been added that prove the fix is effective or that the feature works.
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code).
- [x] Linter has passed locally and any fixes were made for failures.
- [x] A self-review of the code has been done.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [ ] Other (please describe):


## What is the ticket or issue number?
<!-- Please link to a jira ticket or relevant issue. -->

- Ticket Number: N/A
- Issue Number: N/A

## Pull Request Description
By default `rows` is not set when submitting a v2 Process search which defaults to capping the results returned to 500. As explained by @jrhackett on https://github.com/carbonblack/cbapi-python/issues/230#issuecomment-658981005, the current max number of results supported by the platform is 10000. This PR changes the `rows` parameter on process search requests to this value. This does not change the retrieval of the actual results which is still performed in batches of 10 results per the code below:

https://github.com/carbonblack/cbapi-python/blob/a19985e211d07c240c5a46f4c38f12a03c208595/src/cbapi/psc/threathunter/query.py#L491-L497

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?

This was tested with the below code to verify the `len()` of the results 10000 (for a process search that has over 10000 results). Without this change the value for `len()` is the default 500.

```Python
from cbapi.psc.threathunter import CbThreatHunterAPI
from cbapi.psc.threathunter.models import Event, Process

cb = CbThreatHunterAPI(profile='redlab2')
query_result = cb.select(Process).where('process_name:cmd.exe')

print(len(query_result))
```

Output:

```shell
❯ python src/test.py
10000
```