### PR TITLE
Fix resource warnings regarding unclosed file object.

### DIFF
--- a/src/cbapi/models.py
+++ b/src/cbapi/models.py
@@ -35,8 +35,9 @@ class CbMetaModel(type):
         swagger_meta_file = clsdict.pop("swagger_meta_file", None)
         model_data = {}
         if swagger_meta_file:
-            model_data = yaml.safe_load(
-                open(os.path.join(mcs.model_base_directory, swagger_meta_file), 'rb').read())
+            with open(os.path.join(mcs.model_base_directory, swagger_meta_file), 'rb') as f:
+                model_data = yaml.safe_load(f.read())
+
 
         clsdict["__doc__"] = "Represents a %s object in the Carbon Black server.\n\n" % (name,)
         for field_name, field_info in iteritems(model_data.get("properties", {})):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [ ] Code follows the style guidelines of this project (PEP8, clean code).
- [ ] Linter has passed locally and any fixes were made for failures.
- [ ] A self-review of the code has been done.

## Pull request type


Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [ ] Other (please describe):


## What is the ticket or issue number?
<!-- Please link to a jira ticket or relevant issue. -->

- Ticket Number: N/A

- Issue Number: N/A

## Pull Request Description

Unclosed file handles cause warnings during tests. Use context manager.

Sample warning : 
```
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/root/checked_repos/cbapi-python/src/cbapi/models.py:39: ResourceWarning: unclosed file <_io.BufferedReader name='/root/checked_repos/cbapi-python/src/cbapi/psc/livequery/models/facet.yaml'>
  open(os.path.join(mcs.model_base_directory, swagger_meta_file), 'rb').read())
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
