### PR TITLE
PSC Alerts API: requests pages of 100 rows by default

### DIFF
--- a/src/cbapi/psc/alerts_query.py
+++ b/src/cbapi/psc/alerts_query.py
@@ -365,6 +365,7 @@ class BaseAlertSearchQuery(PSCQueryBase, QueryBuilderSupportMixin, IterableQuery
         """
         request = {"criteria": self._build_criteria()}
         request["query"] = self._query_builder._collapse()
+        request["rows"] = 100
         if from_row > 0:
             request["start"] = from_row
         if max_rows >= 0:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code).
- [ ] Linter has passed locally and any fixes were made for failures.
- [x] A self-review of the code has been done.
It's a small fix so I didn't do everything, please let me know if it's blocking...

## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [ ] Other (please describe):


## What is the ticket or issue number?
- Issue Number: #275

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?

I ran a request with https://github.com/carbonblack/cbapi-python/blob/master/examples/psc/list_cbanalytics_alerts.py that returns ~1k alerts. It was much faster and in my proxy I can see the additional `"rows": 100` parameter while the results are now in chunks of 100

## Other information:

Similar to https://github.com/carbonblack/cbapi-python/pull/252

I chose "100" arbitrarily but you might prefer a different default (by default, API returns 20 rows, while UI requests 50).
Moreover, this API client could also allow to pass this as a parameter (isn't implemented here)