### PR TITLE
Support keyword arguments for process callbacks

### DIFF
--- a/src/cbapi/response/models.py
+++ b/src/cbapi/response/models.py
@@ -2427,7 +2427,7 @@ class Process(TaggedModel):
                 log.debug("Unable to parse process GUID %s, marking invalid" % self.id)
                 self.valid_process = False
 
-    def walk_parents(self, callback, max_depth=0, depth=0):
+    def walk_parents(self, callback, max_depth=0, depth=0, **kwargs):
         """
         Walk up the execution chain while calling the specified callback function at each depth.
 
@@ -2458,15 +2458,15 @@ class Process(TaggedModel):
         try:
             parent_proc = self.parent
             if parent_proc and parent_proc.get("process_pid", -1) != -1:
-                callback(parent_proc, depth=depth)
+                callback(parent_proc, depth=depth, **kwargs)
             else:
                 return
         except ObjectNotFoundError:
             return
         else:
-            parent_proc.walk_parents(callback, max_depth=max_depth, depth=depth+1)
+            parent_proc.walk_parents(callback, max_depth=max_depth, depth=depth+1, **kwargs)
 
-    def walk_children(self, callback, max_depth=0, depth=0):
+    def walk_children(self, callback, max_depth=0, depth=0, **kwargs):
         """
         Walk down the execution chain while calling the specified callback function at each depth.
 
@@ -2501,11 +2501,11 @@ class Process(TaggedModel):
             if not cpevent.terminated:
                 try:
                     proc = cpevent.process
-                    callback(proc, depth=depth)
+                    callback(proc, depth=depth, **kwargs)
                 except ObjectNotFoundError:
                     continue
                 else:
-                    proc.walk_children(callback, max_depth=max_depth, depth=depth+1)
+                    proc.walk_children(callback, max_depth=max_depth, depth=depth+1, **kwargs)
 
     @property
     def parent_md5(self):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works. 
- [x] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code).
- [x] Linter has passed locally and any fixes were made for failures.
- [x] A self-review of the code has been done.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [x] Other (please describe): very small "feature" in the form of added flexibility
  

## What is the ticket or issue number?
<!-- Please link to a jira ticket or relevant issue. -->

- Ticket Number: N/A

- Issue Number: N/A

## Pull Request Description
Greater flexibility over process.walk_parents and process.walk_children callbacks.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## How Has This Been Tested?

I added this keyword argument support to simplify a complex correlation we needed to do, as part of a investigation, across hundreds of sensors, in a production environment. 

## Other information:

