### PR TITLE
make cbapi-python accept a pre-configured requests.Session()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -191,6 +191,11 @@ configuration file format specified above.
 The  optional `CBAPI_SSL_VERIFY` envar can be used to control SSL validation(True/False or 0/1), which will default to ON when
 not explicitly set by the user.
 
+For environments where complex outbound network filters and proxy configurations are used (eg. anything other than
+an unauthenticated or basic password authenticated proxy) a prepared `requests.Session` object may be supplied as a
+`proxy_session` parameter. This session will then be used for all communication with the API. Construction of such a
+`Session` is beyond the scope of this document, consult your local network/security administrators for assistance.
+
 Backwards & Forwards Compatibility
 ----------------------------------
 

--- a/src/cbapi/connection.py
+++ b/src/cbapi/connection.py
@@ -143,7 +143,7 @@ class CbAPISessionAdapter(HTTPAdapter):
 class Connection(object):
     """Object that encapsulates the HTTP connection to the CB server."""
 
-    def __init__(self, credentials, integration_name=None, timeout=None, max_retries=None, **pool_kwargs):
+    def __init__(self, credentials, integration_name=None, timeout=None, max_retries=None, proxy_session=None, **pool_kwargs):
         """
         Initialize the Connection object.
 
@@ -184,7 +184,10 @@ class Connection(object):
 
         self.token = credentials.token
         self.token_header = {'X-Auth-Token': self.token, 'User-Agent': user_agent}
-        self.session = requests.Session()
+        if proxy_session:
+            self.session = proxy_session
+        else:
+            self.session = requests.Session()
 
         self._timeout = timeout
 
@@ -371,12 +374,13 @@ class BaseAPI(object):
 
         timeout = kwargs.pop("timeout", DEFAULT_POOL_TIMEOUT)
         max_retries = kwargs.pop("max_retries", DEFAULT_RETRIES)
+        proxy_session = kwargs.pop("proxy_session", None)
         pool_connections = kwargs.pop("pool_connections", 1)
         pool_maxsize = kwargs.pop("pool_maxsize", DEFAULT_POOLSIZE)
         pool_block = kwargs.pop("pool_block", DEFAULT_POOLBLOCK)
 
         self.session = Connection(self.credentials, integration_name=integration_name, timeout=timeout,
-                                  max_retries=max_retries, pool_connections=pool_connections,
+                                  max_retries=max_retries, proxy_session=proxy_session, pool_connections=pool_connections,
                                   pool_maxsize=pool_maxsize, pool_block=pool_block)
 
     def raise_unless_json(self, ret, expected):


### PR DESCRIPTION
Some environments have highly restrictive outbound network filters
and require uncommon proxy configurations, perhaps using
certificate authentication or some library preloads. This diff
allows users to set up an appropriately configured Session() to
be used for access to the CB API.

Example:
```
  # do whatever is necessary to get a requests Session that
  # can access the internet
  from my_special_network_library import internet_proxy
  my_proxy = internet_proxy()

  # quickly check that this proxy is acceptable
  assert isinstance(my_proxy, requests.sessions.Session)
  assert my_proxy.get('http://www.example.com').ok

  # use the proxy session in the CB API
  from cbapi.response import CbEnterpriseResponseAPI, Sensor, SensorGroup
  cb = CbEnterpriseResponseAPI(proxy_session=my_proxy)
```

signed-off-by: chris.kuethe+github@gmail.com

## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code).
- [x] Linter has passed locally and any fixes were made for failures.
- [x] A self-review of the code has been done.

## Pull request type

Feature: add the ability to pass in a user-supplied proxy session.

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes (not tied to bugs/features)
- [ ] Other (please describe):


## What is the ticket or issue number?
<!-- Please link to a jira ticket or relevant issue. -->

- Ticket Number: N/A

- Issue Number: N/A

## Pull Request Description
Some environments have highly restrictive outbound network filters and require uncommon proxy configurations, perhaps using certificate authentication or some library preloads. This diff allows users to set up an appropriately configured Session() to be used for access to the CB API.

Don't worry too much about the exact details of my environment; just trust that I have to do some special things to set up requests to give me outbound access. All that special stuff has been encapsulated into a function that gives me back a requests session. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?

I'm using this in an internal tool that, before the addition of this proxy argument required me to craft my own requests and parse my own responses from the API. Now, I pass in the proxy argument and the rest of cbapi works.

## Other information:

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
