### PR TITLE
CBAPI-1821: Update ReadTheDocs for CBAPI for product names and terminology

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -5,7 +5,7 @@ There are a few critical concepts that will make understanding and using the cba
 explained below, and also covered in a slide deck presented at the Carbon Black regional User Exchanges in 2016.
 You can see the slide deck `here <https://speakerdeck.com/cbdevnet/carbon-black-python-api-summer-2016>`_.
 
-At a high level, the cbapi tries to represent data in CB Response or CB Protection as Python objects. If you've worked
+At a high level, the cbapi tries to represent data in EDR or App Control as Python objects. If you've worked
 with SQL Object-relational Mapping (ORM) frameworks before, then this structure may seem familiar -- cbapi was
 designed to operate much like an ORM such as SQLAlchemy or Ruby's ActiveRecord. If you haven't worked with one of these
 libraries, don't worry! The concepts will become clear after a little practice.
@@ -14,9 +14,9 @@ Model Objects
 -------------
 
 Everything in cbapi is represented in terms of "Model Objects". A Model Object in cbapi represents a single instance
-of a specific type of data in CB Response or Protection. For example, a process document from CB Response (as seen
+of a specific type of data in EDR or App Control. For example, a process document from EDR (as seen
 on an Analyze Process page in the Web UI) is represented as a :py:mod:`cbapi.response.models.Process` Model Object.
-Similarly, a file instance in CB Protection is represented as a  :py:mod:`cbapi.protection.models.FileInstance`
+Similarly, a file instance in App Control is represented as a  :py:mod:`cbapi.protection.models.FileInstance`
 Model Object.
 
 Once you have an instance of a Model Object, you can access all of the data contained within as Python properties.
@@ -27,7 +27,7 @@ in the ``cmdline`` property), you would write the code::
 
 This would automatically retrieve the ``cmdline`` attribute of the process and print it out to your screen.
 
-The data in CB Response and Protection may change rapidly, and so a comprehensive list of valid properties is difficult
+The data in EDR and App Control may change rapidly, and so a comprehensive list of valid properties is difficult
 to keep up-to-date. Therefore, if you are curious what properties are available on a specific Model Object, you can
 print that Model Object to the screen. It will dump all of the available properties and their current values. For
 example::
@@ -56,15 +56,15 @@ method to retrieve the property, and return a default value if the property does
 
 In summary, Model Objects contain all the data associated with a specific type of API call. In this example, the
 :py:mod:`cbapi.response.models.Binary` Model Object reflects all the data available via the
-``/api/v1/binary`` API route on a CB Response server.
+``/api/v1/binary`` API route on an EDR server.
 
 Joining Model Objects
 ---------------------
 
 Many times, there are relationships between different Model Objects. To make navigating these relationships easy,
-cbapi provides special properties to "join" Model Objects together. For example, a :py:mod:`cbapi.response.models.Process`
-Model Object can reference the :py:mod:`cbapi.response.models.Sensor` or :py:mod:`cbapi.response.models.Binary`
-associated with this Process.
+cbapi provides special properties to "join" Model Objects together. For example, a
+:py:mod:`cbapi.response.models.Process` Model Object can reference the :py:mod:`cbapi.response.models.Sensor` or
+:py:mod:`cbapi.response.models.Binary` associated with this Process.
 
 In this case, special "join" properties are provided for you. When you use one of these properties, cbapi will
 automatically retrieve the associated Model Object, if necessary.
@@ -90,13 +90,13 @@ Queries
 
 Now that we've covered how to get data out of a specific Model Object, we now need to learn how to obtain Model
 Objects in the first place! To do this, we have to create and execute a Query. cbapi Queries use the same query
-syntax accepted by CB Response or Protection's APIs, and add a few little helpful features along the way.
+syntax accepted by EDR or App Control's APIs, and add a few little helpful features along the way.
 
 To create a query in cbapi, use the ``.select()`` method on the CbResponseAPI or CbProtectionAPI object. Pass the
 Model Object type as a parameter to the ``.select()`` call and optionally add filtering criteria with ``.where()``
 clauses.
 
-Let's start with a simple query for CB Response::
+Let's start with a simple query for EDR::
 
     >>> from cbapi.response import *
     >>> cb = CbResponseAPI()
@@ -152,15 +152,15 @@ will throw a :py:mod:`MoreThanOneResultError` exception if there are zero or mor
 second method is ``.first()``, which will return the first result from the result set, or None if there are no results.
 
 Every time you access a Query object, it will perform a REST API query to the Carbon Black server. For large result
-sets, the results are retrieved in batches- by default, 100 results per API request on CB Response and 1,000 results
-per API request on CB Protection. The search queries themselves are not cached, but the resulting Model Objects are.
+sets, the results are retrieved in batches- by default, 100 results per API request on EDR and 1,000 results
+per API request on App Control. The search queries themselves are not cached, but the resulting Model Objects are.
 
 Retrieving Objects by ID
 ------------------------
 
 Every Model Object (and in fact any object addressable via the REST API) has a unique ID associated with it. If you
-already have a unique ID for a given Model Object, for example, a Process GUID for CB Response, or a Computer ID
-for CB Protection, you can ask cbapi to give you the associated Model Object for that ID by passing that ID to the
+already have a unique ID for a given Model Object, for example, a Process GUID for EDR, or a Computer ID
+for App Control, you can ask cbapi to give you the associated Model Object for that ID by passing that ID to the
 ``.select()`` call. For example::
 
     >>> binary = cb.select(Binary, "CA4FAFFA957C71C006B59E29DFE3EB8B")
@@ -178,16 +178,16 @@ object and if it does not exist, cbapi will throw a :py:mod:`ObjectNotFoundError
 Creating New Objects
 --------------------
 
-The CB Response and Protection REST APIs provide the ability to insert new data under certain circumstances. For
-example, the CB Response REST API allows you to insert a new banned hash into its database. Model Objects that
+The EDR and App Control REST APIs provide the ability to insert new data under certain circumstances. For
+example, the EDR REST API allows you to insert a new banned hash into its database. Model Objects that
 represent these data types can be "created" in cbapi by using the ``create()`` method::
 
     >>> bh = cb.create(BannedHash)
 
 If you attempt to create a Model Object that cannot be created, you will receive a :py:mod:`ApiError` exception.
 
-Once a Model Object is created, it's blank (it has no data). You will need to set the required properties and then call the
-``.save()`` method::
+Once a Model Object is created, it's blank (it has no data). You will need to set the required properties and then call
+the ``.save()`` method::
 
     >>> bh = cb.create(BannedHash)
     >>> bh.text = "Banned from API"
@@ -199,7 +199,7 @@ exception with a list of the properties that are required and not currently set.
 
 Once the ``.save()`` method is called, the appropriate REST API call is made to create the object. The Model Object
 is then updated to the current state returned by the API, which may include additional data properties initialized
-by CB Response or Protection.
+by EDR or App Control.
 
 Modifying Existing Objects
 --------------------------

--- a/docs/defense-api.rst
+++ b/docs/defense-api.rst
@@ -1,14 +1,14 @@
 .. _defense_api:
 
-CB Defense API
-==============
+Cloud Endpoint Standard API
+===========================
 
-This page documents the public interfaces exposed by cbapi when communicating with a CB Defense server.
+This page documents the public interfaces exposed by cbapi when communicating with a Cloud Endpoint Standard server.
 
 Main Interface
 --------------
 
-To use cbapi with Carbon Black Defense, you will be using the CBDefenseAPI.
+To use cbapi with VMware Carbon Black Cloud Endpoint Standard, you will be using the CBDefenseAPI.
 The CBDefenseAPI object then exposes two main methods to select data on the Carbon Black server:
 
 .. autoclass:: cbapi.psc.defense.rest_api.CbDefenseAPI

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -4,24 +4,25 @@ Getting Started
 First, let's make sure that your API authentication tokens have been imported into cbapi. Once that's done, then read
 on for the key concepts that will explain how to interact with Carbon Black APIs via cbapi.
 
-Feel free to follow along with this document or watch the `Development Environment Setup video <https://developer.carbonblack.com/guide/enterprise-response/development-environment-video/>`_
+Feel free to follow along with this document or watch the
+`Development Environment Setup video <https://developer.carbonblack.com/guide/enterprise-response/development-environment-video/>`_
 on the Developer Network website.
 
 API Authentication
 ------------------
 
-CB Response and CB Protection use a per-user API secret token to authenticate requests via the API. The API token
-confers the same permissions and authorization as the user it is associated with, so protect the API token with the
-same care as a password.
+VMware Carbon Black EDR and App Control use a per-user API secret token to authenticate requests via the API. The API
+token confers the same permissions and authorization as the user it is associated with, so protect the API token with
+the same care as a password.
 
 To learn how to obtain the API token for a user, see the Developer Network website: there you will find instructions
-for obtaining an API token for `CB Response <https://developer.carbonblack.com/reference/enterprise-response/authentication/>`_
-and `CB Protection <https://developer.carbonblack.com/reference/enterprise-protection/authentication/>`_.
+for obtaining an API token for `EDR <https://developer.carbonblack.com/reference/enterprise-response/authentication/>`_
+and `App Control <https://developer.carbonblack.com/reference/enterprise-protection/authentication/>`_.
 
 Once you have the API token, cbapi helps keep your credentials secret by enforcing the use of a credential file. To
 encourage sharing of scripts across the community while at the same time protecting the security of our customers,
 cbapi strongly discourages embedding credentials in individual scripts. Instead, you can place credentials for several
-CB Response or CB Protection servers inside the API credential file and select which "profile" you would like to use
+EDR or App Control servers inside the API credential file and select which "profile" you would like to use
 at runtime.
 
 To create the initial credential file, a simple-to-use script is provided. Just run the ``cbapi-response``,
@@ -36,7 +37,8 @@ Alternatively, if you're using Windows (change ``c:\python27`` if Python is inst
 This configuration script will walk you through entering your API credentials and will save them to your current user's
 credential file location, which is located in the ``.carbonblack`` directory in your user's home directory.
 
-If using cbapi-psc, you will also be asked to provide an org key. An org key is required to access the Carbon Black Cloud, and can be found in the console under Settings -> API Keys.
+If using cbapi-psc, you will also be asked to provide an org key. An org key is required to access the Carbon Black
+Cloud, and can be found in the console under Settings -> API Keys.
 
 Your First Query
 ----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,9 +8,10 @@ cbapi: Carbon Black API for Python
 
 Release v\ |release|.
 
-cbapi provides a straightforward interface to the Carbon Black products: CB Protection, Response, and Defense.
-This library provides a Pythonic layer to access the raw power of the REST APIs of all CB products, making it trivial
-to do the easy stuff and handling all of the "sharp corners" behind the scenes for you. Take a look::
+cbapi provides a straightforward interface to the VMware Carbon Black products: App Control, EDR, and Cloud Endpoint
+Standard.  This library provides a Pythonic layer to access the raw power of the REST APIs of all VMware Carbon Black
+products, making it trivial to do the easy stuff and handling all of the "sharp corners" behind the scenes for you.
+Take a look::
 
    >>> from cbapi.response import CbResponseAPI, Process, Binary, Sensor
    >>> #
@@ -39,7 +40,7 @@ to do the easy stuff and handling all of the "sharp corners" behind the scenes f
    ...     s.network_isolation_enabled = True
    ...     s.save()
 
-If you're more a CB Protection fellow, then you're in luck as well::
+If you're more an App Control fellow, then you're in luck as well::
 
    >>> from cbapi.protection.models import FileInstance
    >>> from cbapi.protection import CbProtectionAPI
@@ -62,7 +63,7 @@ If you're more a CB Protection fellow, then you're in luck as well::
    >>> fi.computer.policyId = 3
    >>> fi.computer.save()
 
-As of version 1.2, cbapi now provides support for CB Defense too!
+As of version 1.2, cbapi now provides support for Cloud Endpoint Standard too!
 
    >>> from cbapi.psc.defense import *
    >>> #
@@ -85,19 +86,19 @@ Major Features
 --------------
 
 - **Enhanced Live Response API**
-    The new cbapi now provides a robust interface to the CB Response Live Response capability.
+    The new cbapi now provides a robust interface to the EDR Live Response capability.
     Easily create Live Response sessions, initiate commands on remote hosts, and pull down data as
     necessary to make your Incident Response process much more efficient and automated.
 
-- **Consistent API for CB Response, Protection and Defense platforms**
-    We now support CB Response, Protection and Defense users in the same API layer. Even better,
+- **Consistent API for EDR, App Control and Cloud Endpoint Standard platforms**
+    We now support EDR, App Control and Cloud Endpoint Standard users in the same API layer. Even better,
     the object model is the same for both; if you know one API you can easily transition to the other. cbapi
     hides all the differences between the three REST APIs behind a single, consistent Python-like interface.
 
 - **Enhanced Performance**
     cbapi now provides a built in caching layer to reduce the query load on the Carbon Black server. This is especially
     useful when taking advantage of cbapi's new "joining" features. You can transparently access, for example, the
-    binary associated with a given process in CB Response. Since many processes may be associated
+    binary associated with a given process in EDR. Since many processes may be associated
     with the same binary, it does not make sense to repeatedly request the same binary information from the server
     over and over again. Therefore cbapi now caches this information to avoid unnecessary requests.
 
@@ -111,7 +112,7 @@ Major Features
 
 - **Better support for multiple CB servers**
     cbapi now introduces the concept of Credential Profiles; named collections of URL, API keys, and optional proxy
-    configuration for connecting to any number of CB Protection, Defense, or Response servers.
+    configuration for connecting to any number of App Control, Cloud Endpoint Standard, or EDR servers.
 
 
 API Credentials
@@ -121,9 +122,9 @@ The new cbapi as of version 0.9.0 enforces the use of credential files.
 
 In order to perform any queries via the API, you will need to get the API token for your CB user. See the documentation
 on the Developer Network website on how to acquire the API token for
-`CB Response <http://developer.carbonblack.com/reference/enterprise-response/authentication/>`_,
-`CB Protection <http://developer.carbonblack.com/reference/enterprise-protection/authentication/>`_, or
-`CB Defense <http://developer.carbonblack.com/reference/cb-defense/authentication/>`_.
+`EDR <http://developer.carbonblack.com/reference/enterprise-response/authentication/>`_,
+`App Control <http://developer.carbonblack.com/reference/enterprise-protection/authentication/>`_, or
+`Cloud Endpoint Standard <http://developer.carbonblack.com/reference/cb-defense/authentication/>`_.
 
 Once you acquire your API token, place it in one of the default credentials file locations:
 
@@ -131,13 +132,15 @@ Once you acquire your API token, place it in one of the default credentials file
 * ``~/.carbonblack/``
 * ``/current_working_directory/.carbonblack/``
 
-For distinction between credentials of different Carbon Black products, use the following naming convention for your credentials files:
+For distinction between credentials of different Carbon Black products, use the following naming convention for your
+credentials files:
 
-* ``credentials.psc`` for CB Defense, CB ThreatHunter, and CB LiveOps
-* ``credentials.response`` for CB Response
-* ``credentials.protection`` for CB Protection
+* ``credentials.psc`` for Cloud Endpoint Standard, Enterprise EDR, and Audit and Remediation
+* ``credentials.response`` for EDR
+* ``credentials.protection`` for App Control
 
-For example, if you use a Carbon Black Cloud product, you should have created a credentials file in one of these locations:
+For example, if you use a Carbon Black Cloud product, you should have created a credentials file in one of these
+locations:
 
 * ``/etc/carbonblack/credentials.psc``
 * ``~/.carbonblack/credentials.psc``
@@ -170,10 +173,11 @@ The possible options for each credential profile are:
   different tokens for each.
 * **ssl_verify**: True or False; controls whether the SSL/TLS certificate presented by the server is validated against
   the local trusted CA store.
-* **org_key**: The organization key. This is required to access the Carbon Black Cloud, and can be found in the console. The format is ``123ABC45``.
+* **org_key**: The organization key. This is required to access the Carbon Black Cloud, and can be found in the
+  console. The format is ``123ABC45``.
 * **proxy**: A proxy specification that will be used when connecting to the CB server. The format is:
-  ``http://myusername:mypassword@proxy.company.com:8001/`` where the hostname of the proxy is ``proxy.company.com``, port
-  8001, and using username/password ``myusername`` and ``mypassword`` respectively.
+  ``http://myusername:mypassword@proxy.company.com:8001/`` where the hostname of the proxy is ``proxy.company.com``,
+  port 8001, and using username/password ``myusername`` and ``mypassword`` respectively.
 * **ignore_system_proxy**: If you have a system-wide proxy specified, setting this to True will force cbapi to bypass
   the proxy and directly connect to the CB server.
 
@@ -184,13 +188,14 @@ Environment Variable Support
 
 The latest cbapi for python supports specifying API credentials in the following three environment variables:
 
-`CBAPI_TOKEN` the envar for holding the CbR/CbP api token or the ConnectorId/APIKEY combination for CB Defense/Carbon Black Cloud.
+`CBAPI_TOKEN` the envar for holding the EDR/AppC API token or the ConnectorId/APIKEY combination for Cloud Endpoint
+Standard.
 
-The `CBAPI_URL` envar holds the FQDN of the target, a CbR , CBD, or CbD/Carbon Black Cloud server specified just as they are in the
-configuration file format specified above.
+The `CBAPI_URL` envar holds the FQDN of the target, a EDR, AppC, or Cloud Endpoint Standard server specified just as
+they are in the configuration file format specified above.
 
-The  optional `CBAPI_SSL_VERIFY` envar can be used to control SSL validation(True/False or 0/1), which will default to ON when
-not explicitly set by the user.
+The  optional `CBAPI_SSL_VERIFY` envar can be used to control SSL validation(True/False or 0/1), which will default to
+ON when not explicitly set by the user.
 
 Backwards & Forwards Compatibility
 ----------------------------------
@@ -207,8 +212,8 @@ legacy scripts cannot run under Python 3.
 Once cbapi 1.0.0 is released, the old :py:mod:`cbapi.legacy.CbApi` will be deprecated and removed entirely no earlier
 than January 2017.
 New scripts should use the :py:mod:`cbapi.response.rest_api.CbResponseAPI`
-(for CB Response), :py:mod:`cbapi.protection.rest_api.CbProtectionAPI`
-(for CB Protection), or :py:mod:`cbapi.defense.rest_api.CbDefenseAPI` API entry points.
+(for EDR), :py:mod:`cbapi.protection.rest_api.CbProtectionAPI`
+(for App Control), or :py:mod:`cbapi.defense.rest_api.CbDefenseAPI` API entry points.
 
 The API is frozen as of version 1.0; afterward, any changes in the 1.x version branch
 will be additions/bug fixes only. Breaking changes to the API will increment the major version number (2.x).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Take a look::
 
    >>> from cbapi.response import CbResponseAPI, Process, Binary, Sensor
    >>> #
-   >>> # Create our CbAPI object
+   >>> # Create our EDR API object
    >>> #
    >>> c = CbResponseAPI()
    >>> #
@@ -45,7 +45,7 @@ If you're more an App Control fellow, then you're in luck as well::
    >>> from cbapi.protection.models import FileInstance
    >>> from cbapi.protection import CbProtectionAPI
    >>> #
-   >>> # Create our CB Protection API object
+   >>> # Create our App Control API object
    >>> #
    >>> p = CbProtectionAPI()
    >>> #
@@ -67,7 +67,7 @@ As of version 1.2, cbapi now provides support for Cloud Endpoint Standard too!
 
    >>> from cbapi.psc.defense import *
    >>> #
-   >>> # Create our CB Defense API object
+   >>> # Create our Cloud Endpoint Standard API object
    >>> #
    >>> p = CbDefenseAPI()
    >>> #

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,11 +1,12 @@
 Installation
 ============
 
-Before installing cbapi, make sure that you have access to a working CB Response or CB Protection server. The server
-can be either on-premise or in the cloud. CB Response clusters are also supported. Once you have access to a working
-can use the standard Python packaging tools to install cbapi on your local machine.
+Before installing cbapi, make sure that you have access to a working VMWare Carbon Black EDR or App Control server.
+The server can be either on-premise or in the cloud. EDR clusters are also supported. Once you have access to a working
+server, you can use the standard Python packaging tools to install cbapi on your local machine.
 
-Feel free to follow along with this document or watch the `Development Environment Setup video <https://developer.carbonblack.com/guide/enterprise-response/development-environment-video/>`_
+Feel free to follow along with this document or watch the
+`Development Environment Setup video <https://developer.carbonblack.com/guide/enterprise-response/development-environment-video/>`_
 on the Developer Network website.
 
 If you already have Python installed, you can skip right down to "Using Pip".
@@ -40,8 +41,7 @@ https://www.python.org/ftp/python/3.6.4/python-3.6.4-amd64.exe.
    :alt: Windows installation options showing "Add python.exe to path"
    :align: right
 
-Ensure that the "Add Python to PATH" option is
-checked.
+Ensure that the "Add Python to PATH" option is checked.
 
 If for some reason you do not have pip installed, follow the instructions at this
 `handy guide <http://docs.python-guide.org/en/latest/starting/installation/>`_.

--- a/docs/live-response.rst
+++ b/docs/live-response.rst
@@ -30,7 +30,7 @@ Since the Live Response API is synchronous, the script will not continue until e
 established and the file contents are retrieved, or an exception occurs (in this case, either a timeout error or
 an error reading the file).
 
-As seen in the example above, the ``.lr_session()`` method is context-aware. CB Response has a limited number of
+As seen in the example above, the ``.lr_session()`` method is context-aware. EDR has a limited number of
 concurrent Live Response session slots (by default, only ten). By wrapping the ``.lr_session()`` call within a
 ``with`` context, the session is automatically closed at the end of the block and frees that slot for another
 concurrent Live Response session in another script or user context.

--- a/docs/live-response.rst
+++ b/docs/live-response.rst
@@ -1,7 +1,7 @@
 CbAPI and Live Response
 =======================
 
-Working with the CB Live Response REST API directly can be difficult. Thankfully, just like the rest of Carbon
+Working with the Live Response REST API directly can be difficult. Thankfully, just like the rest of Carbon
 Black's REST APIs, cbapi provides Pythonic APIs to make working with the Live Response API much easier.
 
 In addition to easy-to-use APIs to call into Live Response, cbapi also provides a "job-based" interface that allows

--- a/docs/livequery-api.rst
+++ b/docs/livequery-api.rst
@@ -1,10 +1,9 @@
 .. _livequery_api:
 
 CB LiveQuery API
-===================
+================
 
-This page documents the public interfaces exposed by cbapi when communicating with
-Carbon Black LiveQuery devices.
+This page documents the public interfaces exposed by cbapi when communicating with Carbon Black LiveQuery devices.
 
 Main Interface
 --------------
@@ -20,9 +19,8 @@ The LiveQuery API is used in two stages: run submission and result retrieval.
 Queries
 -------
 
-The LiveQuery API uses QueryBuilder instances to construct structured
-or unstructured (i.e., raw string) queries. You can either construct these
-instances manually, or allow ``CbLiveQueryAPI.select()`` to do it for you:
+The LiveQuery API uses QueryBuilder instances to construct structured or unstructured (i.e., raw string) queries.
+You can either construct these instances manually, or allow ``CbLiveQueryAPI.select()`` to do it for you:
 
 .. autoclass:: cbapi.psc.livequery.query.QueryBuilder
     :members:

--- a/docs/livequery-examples.rst
+++ b/docs/livequery-examples.rst
@@ -14,13 +14,13 @@ Now that we've imported the necessary libraries, we can perform some queries on 
 Create a Query Run
 ----------------------------------
 
-Let's create a Query Run. First, we specify which profile to use for authentication from our credentials.psc file and create the LiveQuery object.
+Let's create a Query Run. First, we specify which profile to use for authentication from our credentials.psc file and
+create the LiveQuery object.
 
     >>> profile = "default'
     >>> cb = CbLiveQueryAPI(profile=profile)
 
 Now, we specify the SQL query that we want to run, name of the run, device IDs, and device types.
-
 
     >>> sql = 'select * from logged_in_users;'
     >>> name_of_run = 'Selecting all logged in users'
@@ -41,7 +41,8 @@ Finally, we submit the query and print the results.
 
 This query should return all logged in Windows endpoints with a ``device_id`` of ``1234567``.
 
-The same query can be executed with the example script `manage_run.py <https://github.com/carbonblack/cbapi-python/blob/master/examples/livequery/manage_run.py>`_. ::
+The same query can be executed with the example script
+`manage_run.py <https://github.com/carbonblack/cbapi-python/blob/master/examples/livequery/manage_run.py>`_. ::
 
     python manage_run.py --profile default create --sql 'select * from logged_in_users;' --name 'Selecting all logged in users' --device_ids '1234567' --device_types 'WINDOWS'
 
@@ -50,7 +51,8 @@ Other possible arguments to ``manage_run.py`` include ``--notify`` and ``--polic
 Get Query Run Status
 ---------------------
 
-Now that we've created a Query Run, let's check the status. If we haven't already authenticated with a credentials profile, we begin by specifying which profile to authenticate with.
+Now that we've created a Query Run, let's check the status. If we haven't already authenticated with a credentials
+profile, we begin by specifying which profile to authenticate with.
 
     >>> profile = 'default'
     >>> cb = CbLiveQueryAPI(profile=profile)
@@ -61,11 +63,13 @@ Next, we select the run with the unique run ID.
     >>> run = cb.select(Run, run_id)
     >>> print(run)
 
-This can also be accomplished with the example script `manage_run.py <https://github.com/carbonblack/cbapi-python/blob/master/examples/livequery/manage_run.py>`_::
+This can also be accomplished with the example script
+`manage_run.py <https://github.com/carbonblack/cbapi-python/blob/master/examples/livequery/manage_run.py>`_::
 
     python manage_run.py --profile default --id a4oh4fqtmrr8uxrdj6mm0mbjsyhdhhvz
 
-In addition, you can specify which order you want results returned. To change from the default ascending order, use the flag ``-d`` or ``--descending_results``::
+In addition, you can specify which order you want results returned. To change from the default ascending order, use
+the flag ``-d`` or ``--descending_results``::
 
     python manage_run.py --profile default --id a4oh4fqtmrr8uxrdj6mm0mbjsyhdhhvz --descending_results
 
@@ -105,6 +109,7 @@ Finally, we print the results.
     ...     print(result)
 
 
-You can also retrieve run results with the example script `run_search.py <https://github.com/carbonblack/cbapi-python/blob/master/examples/livequery/run_search.py>`_::
+You can also retrieve run results with the example script
+`run_search.py <https://github.com/carbonblack/cbapi-python/blob/master/examples/livequery/run_search.py>`_::
 
     python run_search.py --profile default --id a4oh4fqtmrr8uxrdj6mm0mbjsyhdhhvz --device_ids '1234567' --status 'matched'

--- a/docs/protection-api.rst
+++ b/docs/protection-api.rst
@@ -1,15 +1,14 @@
 .. _protection_api:
 
-CB Protection API
-=================
+VMware Carbon Black App Control API
+===================================
 
-This page documents the public interfaces exposed by cbapi when communicating with a Carbon Black Enterprise
-Protection server.
+This page documents the public interfaces exposed by cbapi when communicating with an App Control server.
 
 Main Interface
 --------------
 
-To use cbapi with Carbon Black Protection, you will be using the CbProtectionAPI.
+To use cbapi with VMware Carbon Black App Control, you will be using the CbProtectionAPI.
 The CbProtectionAPI object then exposes two main methods to select data on the Carbon Black server:
 
 .. autoclass:: cbapi.protection.rest_api.CbProtectionAPI

--- a/docs/psc-api.rst
+++ b/docs/psc-api.rst
@@ -1,15 +1,14 @@
 .. _psc_api:
 
-CB PSC API
-==========
+VMware Carbon Black Cloud API
+=============================
 
-This page documents the public interfaces exposed by cbapi when communicating with
-the Carbon Black Predictive Security Cloud (PSC).
+This page documents the public interfaces exposed by cbapi when communicating with the VMware Carbon Black Cloud.
 
 Main Interface
 --------------
 
-To use cbapi with the Carbon Black PSC, you use CbPSCBaseAPI objects.
+To use cbapi with the VMware Carbon Black Cloud, you use CbPSCBaseAPI objects.
 
 .. autoclass:: cbapi.psc.rest_api.CbPSCBaseAPI
     :members:
@@ -18,7 +17,7 @@ To use cbapi with the Carbon Black PSC, you use CbPSCBaseAPI objects.
 Device API
 ----------
 
-The PSC can be used to enumerate devices within your organization, and change their
+The Carbon Black Cloud can be used to enumerate devices within your organization, and change their
 status via a control request.
 
 You can use the select() method on the CbPSCBaseAPI to create a query object for
@@ -45,12 +44,11 @@ Selects all devices running Linux from the current organization.
 Alerts API
 ----------
 
-Using the API, you can search for alerts within your organization, and dismiss or
-undismiss them, either individually or in bulk.
+Using the API, you can search for alerts within your organization, and dismiss or undismiss them, either individually
+or in bulk.
 
-You can use the select() method on the CbPSCBaseAPI to create a query object for
-BaseAlert objects, which can be used to locate a list of alerts.  You can also
-search for more specialized alert types:
+You can use the select() method on the CbPSCBaseAPI to create a query object for BaseAlert objects, which can be used
+to locate a list of alerts.  You can also search for more specialized alert types:
 
 * CBAnalyticsAlert - Alerts from CB Analytics
 * VMwareAlert - Alerts from VMware

--- a/docs/response-api.rst
+++ b/docs/response-api.rst
@@ -1,16 +1,16 @@
 .. _response_api:
 
-CB Response API
-===============
+VMware Carbon Black EDR API
+===========================
 
-This page documents the public interfaces exposed by cbapi when communicating with a Carbon Black Enterprise
-Response server.
+This page documents the public interfaces exposed by cbapi when communicating with a VMware Carbon Black EDR server.
 
 Main Interface
 --------------
 
-To use cbapi with Carbon Black Response, you will be using the CbResponseAPI.
-The CbResponseAPI object then exposes two main methods to access data on the Carbon Black server: ``select`` and ``create``.
+To use cbapi with EDR, you will be using the CbResponseAPI.
+The CbResponseAPI object then exposes two main methods to access data on the Carbon Black server:
+``select`` and ``create``.
 
 .. autoclass:: cbapi.response.rest_api.CbResponseAPI
     :members:

--- a/docs/response-examples.rst
+++ b/docs/response-examples.rst
@@ -1,9 +1,9 @@
-CB Response API Examples
-========================
+VMware Carbon Black EDR Examples
+================================
 
-Now that we've covered the basics, let's step through a few examples using the CB Response API. In these examples,
+Now that we've covered the basics, let's step through a few examples using the EDR API. In these examples,
 we will assume the following boilerplate code to enable logging and establish a connection to the "default"
-CB Response server in our credential file::
+EDR server in our credential file::
 
     >>> import logging
     >>> root = logging.getLogger()
@@ -15,10 +15,10 @@ CB Response server in our credential file::
 
 With that boilerplate out of the way, let's take a look at a few examples.
 
-Download a Binary from CB Response
-----------------------------------
+Download a Binary from EDR
+--------------------------
 
-Let's grab a binary that CB Response has collected from one of the endpoints. This can be useful if you want to
+Let's grab a binary that EDR has collected from one of the endpoints. This can be useful if you want to
 send this binary for further automated analysis or pull it down for manual reverse engineering. You can see a full
 example with command line options in the examples directory: ``binary_download.py``.
 
@@ -58,13 +58,13 @@ Now let's take this binary and add a Banning rule for it. To do this, we create 
     Received response: {u'result': u'success'}
     HTTP GET /api/v1/banning/blacklist/7FB55F5A62E78AF9B58D08AAEEAEF848 took 0.039s (response 200)
 
-Note that if the hash is already banned in CB Response, then you will receive a `ServerError` exception with the message that
+Note that if the hash is already banned in EDR, then you will receive a `ServerError` exception with the message that
 the banned hash already exists.
 
 Isolate a Sensor
 ----------------
 
-Switching gears, let's take a Sensor and quarantine it from the network. The CB Response network isolation
+Switching gears, let's take a Sensor and quarantine it from the network. The EDR network isolation
 functionality allows administrators to isolate endpoints that may be actively involved in an incident, while preserving
 access to perform Live Response on that endpoint and collect further endpoint telemetry.
 
@@ -82,7 +82,7 @@ This will select the first sensor that matches the hostname ``HOSTNAME``. Now we
     ...
     True
 
-The ``.isolate()`` method will keep polling the CB Response server until the sensor has confirmed that it is now
+The ``.isolate()`` method will keep polling the EDR server until the sensor has confirmed that it is now
 isolated from the network. If the sensor is offline or otherwise unreachable, this call could never return. Therefore,
 there is also a ``timeout=`` keyword parameter that can be used to set an optional timeout that, if reached,
 will throw a ``TimeoutError`` exception. The ``.isolate()`` function returns True when the sensor is successfully
@@ -104,7 +104,7 @@ you can optionally specify a timeout using the ``timeout=`` keyword parameter.
 Querying Processes and Events
 -----------------------------
 
-Now, let's do some queries into the CB Response database. The true power of CB Response is its continuous recording
+Now, let's do some queries into the EDR database. The true power of EDR is its continuous recording
 and powerful query language that allows you to go back in time and track the root cause of any security incident on
 your endpoints. Let's start with a simple query to find instances of a specific behavioral IOC, where our attacker
 used the built-in Windows tool ``net.exe`` to mount an internal network share. We will iterate over all uses
@@ -175,42 +175,42 @@ New Filters: Group By, Time Restrictions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the query above, there is an extra ``.group_by()`` method. This method is new in cbapi 1.1.0 and is part of five
-new query filters available when communicating with a CB Response 6.1 server. These filters are accessible via methods
+new query filters available when communicating with an EDR 6.1 server. These filters are accessible via methods
 on the ``Process`` Query object. These new methods are:
 
 * ``.group_by()`` - Group the result set by a field in the response. Typically you will want to group by ``id``, which
   will ensure that the result set only has one result per *process* rather than one result per *event segment*. For
-  more information on processes, process segments, and how segments are stored in CB Response 6.0, see the
-  `Process API Changes for CB Response 6.0 <https://developer.carbonblack.com/reference/enterprise-response/6.1/process-api-changes/>`_
+  more information on processes, process segments, and how segments are stored in EDR 6.0, see the
+  `Process API Changes for EDR 6.0 <https://developer.carbonblack.com/reference/enterprise-response/6.1/process-api-changes/>`_
   page on the Developer Network website.
 * ``.min_last_update()`` - Only return processes that have events after a given date/time stamp (relative to the
   individual sensor's clock)
 * ``.max_last_update()`` - Only return processes that have events before a given date/time stamp (relative to the
   individual sensor's clock)
 * ``.min_last_server_update()`` - Only return processes that have events after a given date/time stamp (relative to the
-  CB Response server's clock)
+  EDR server's clock)
 * ``.max_last_server_update()`` - Only return processes that have events before a given date/time stamp (relative to the
-  CB Response server's clock)
+  EDR server's clock)
 
-CB Response 6.1 uses a new way of recording process events that greatly increases the speed and scale of collection,
+EDR 6.1 uses a new way of recording process events that greatly increases the speed and scale of collection,
 allowing you to store and search data for more endpoints on the same hardware. Details on the new database format
-can be found on the Developer Network website at the `Process API Changes for CB Response 6.0
+can be found on the Developer Network website at the `Process API Changes for EDR 6.0
 <https://developer.carbonblack.com/reference/enterprise-response/6.1/process-api-changes/>`_ page.
 
-The ``Process`` Model Object traditionally referred to a single "segment" of events in the CB Response database. In
-CB Response versions prior to 6.0, a single segment will include up to 10,000 individual endpoint events, enough to
+The ``Process`` Model Object traditionally referred to a single "segment" of events in the EDR database. In
+EDR versions prior to 6.0, a single segment will include up to 10,000 individual endpoint events, enough to
 handle over 95% of the typical event activity for a given process. Therefore, even though a ``Process`` Model Object
 technically refers to a single *segment* in a process, since most processes had less than 10,000 events and therefore
 were only comprised of a single segment, this distinction wasn't necessary.
 
 However, now that processes are split across many segments, a better way of handling this is necessary. Therefore,
-CB Response 6.0 introduces the new ``.group_by()`` method.
+EDR 6.0 introduces the new ``.group_by()`` method.
 
 More on Filters
 ~~~~~~~~~~~~~~~
 
 Querying for a process will return *all* segments that match. For example, if you search for ``process_name:cmd.exe``,
-the result set will include *all* segments of *all* ``cmd.exe`` processes. Therefore, CB Response 6.1 introduced
+the result set will include *all* segments of *all* ``cmd.exe`` processes. Therefore, EDR 6.1 introduced
 the ability to "group" result sets by a field in the result. Typically you will want to group by the internal process
 id (the ``id`` field), and this is what we did in the query above. Grouping by the ``id`` field will ensure that only
 one result is returned per *process* rather than per *segment*.
@@ -230,7 +230,7 @@ Let's take a look at an example::
     00000001-0000-0e48-01d2-c2a397f4cfe0 1495463176570
     00000001-0000-0e48-01d2-c2a397f4cfe0 1495463243492
 
-Notice that the "same" process ID is returned seven times, but with seven different segment IDs. CB Response will
+Notice that the "same" process ID is returned seven times, but with seven different segment IDs. EDR will
 return *every* process event segment that matches a given query, in this case, any event segment that contains the
 process command name ``cmd.exe``.
 
@@ -246,9 +246,9 @@ the command name ``cmd.exe``. Just add the ``.group_by("id")`` filter to your qu
 Feed and Watchlist Maintenance
 ------------------------------
 
-The cbapi provides several helper functions to assist in creating watchlists and
+The cbapi provides several helper functions to assist in creating watchlists and feeds.
 
-Watchlists are simply saved Queries that are automatically run on the CB Response server on a periodic basis. Results
+Watchlists are simply saved Queries that are automatically run on the EDR server on a periodic basis. Results
 of the watchlist are tagged in the database and optionally trigger alerts. Therefore, a cbapi Query can easily be
 converted into a watchlist through the Query ``.create_watchlist()`` function::
 
@@ -295,9 +295,10 @@ The cbapi provides helper functions to manage alerts and threat reports in bulk.
 the ThreatReport and Alert Model Objects provide a few bulk operations to help manage large numbers of Threat Reports
 and Alerts, respectively.
 
-To mark a large number of Threat Reports as false positives, create a query that matches the Reports you're interested in.
-For example, if every Report from the Feed named "SOC" that contains the word "FUZZYWOMBAT" in the report title should be
-considered a false positive (and no longer trigger Alerts), you can write the following code to do so::
+To mark a large number of Threat Reports as false positives, create a query that matches the Reports you're
+interested in.  For example, if every Report from the Feed named "SOC" that contains the word "FUZZYWOMBAT" in the
+report title should be considered a false positive (and no longer trigger Alerts), you can write the following code
+to do so::
 
     >>> feed = c.select(Feed).where("name:SOC").one()
     >>> report_query = feed.reports.where("title:FUZZYWOMBAT")
@@ -359,7 +360,7 @@ Those few lines of Python above are jam-packed with functionality. Now for each 
 contextual information on the source host, the group that host is part of, and details about the signing status of the
 binary that was executed. The magic is performed behind the scenes when we use the ``.binary`` and ``.sensor`` properties
 on the Process Model Object. Just like our previous example, cbapi's caching layer ensures that we do not overload
-the CB Response server with duplicate requests for the same data. In this example, multiple redundant requests for sensor,
+the EDR server with duplicate requests for the same data. In this example, multiple redundant requests for sensor,
 sensor group, and binary data are all eliminated by cbapi's cache.
 
 Facets
@@ -395,7 +396,7 @@ Administrative Tasks
 
 In addition to querying data, you can also perform various administrative tasks using cbapi.
 
-Let's create a user on our CB Response server::
+Let's create a user on our EDR server::
 
     >>> user = cb.create(User)
     >>> user.username = "jgarman"

--- a/docs/threathunter-api.rst
+++ b/docs/threathunter-api.rst
@@ -1,17 +1,16 @@
 .. _threathunter_api:
 
-CB ThreatHunter API
-===================
+VMware Carbon Black Cloud Enterprise EDR API
+============================================
 
 This page documents the public interfaces exposed by cbapi when communicating with a
-Carbon Black Cloud ThreatHunter server.
+VMware Carbon Black Cloud Enterprise EDR server.
 
 Main Interface
 --------------
 
-To use cbapi with Carbon Black ThreatHunter, you use CbThreatHunterAPI objects.
-These objects expose two main methods to access data on the
-ThreatHunter server: ``select`` and ``create``.
+To use cbapi with Enterprise EDR, you use CbThreatHunterAPI objects.
+These objects expose two main methods to access data on the Enterprise EDR server: ``select`` and ``create``.
 
 .. autoclass:: cbapi.psc.threathunter.rest_api.CbThreatHunterAPI
     :members:
@@ -20,7 +19,7 @@ ThreatHunter server: ``select`` and ``create``.
 Queries
 -------
 
-The ThreatHunter API uses QueryBuilder instances to construct structured
+The Enterprise EDR API uses QueryBuilder instances to construct structured
 or unstructured (i.e., raw string) queries. You can either construct these
 instances manually, or allow ``CbThreatHunterAPI.select()`` to do it for you:
 

--- a/src/cbapi/protection/rest_api.py
+++ b/src/cbapi/protection/rest_api.py
@@ -11,15 +11,15 @@ log = logging.getLogger(__name__)
 
 
 class CbProtectionAPI(BaseAPI):
-    """The main entry point into the Carbon Black Enterprise Protection API.
+    """The main entry point into the Carbon Black App Control API.
 
     :param str profile: (optional) Use the credentials in the named profile when connecting to the Carbon Black server.
         Uses the profile named 'default' when not specified.
 
     Usage::
 
-    >>> from cbapi import CbEnterpriseProtectionAPI
-    >>> cb = CbEnterpriseProtectionAPI(profile="production")
+    >>> from cbapi import CbProtectionAPI
+    >>> cb = CbProtectionAPI(profile="production")
     """
     def __init__(self, *args, **kwargs):
         super(CbProtectionAPI, self).__init__(product_name="protection", *args, **kwargs)
@@ -76,11 +76,11 @@ class CbEnterpriseProtectionAPI(CbProtectionAPI):
 
 
 class Query(PaginatedQuery):
-    """Represents a prepared query to the Carbon Black Enterprise Protection server.
+    """Represents a prepared query to the Carbon Black App Control server.
 
-    This object is returned as part of a :py:meth:`CbEnterpriseProtectionAPI.select`
+    This object is returned as part of a :py:meth:`CbProtectionAPI.select`
     operation on models requested from the Carbon Black
-    Enterprise Protection server. You should not have to create this class yourself.
+    App Control server. You should not have to create this class yourself.
 
     The query is not executed on the server until it's accessed, either as an iterator (where it will generate values
     on demand as they're requested) or as a list (where it will retrieve the entire result set and save to a list).
@@ -88,12 +88,12 @@ class Query(PaginatedQuery):
     the query.
 
     The syntax for query :py:meth:where and :py:meth:sort methods can be found in the
-    `Enterprise Protection API reference`_ posted on the Carbon Black Developer Network website.
+    `App Control REST API reference`_ posted on the Carbon Black Developer Network website.
 
     Examples::
 
-    >>> from cbapi.protection import CbEnterpriseProtectionAPI, Computer
-    >>> cb = CbEnterpriseProtectionAPI()
+    >>> from cbapi.protection import CbProtectionAPI, Computer
+    >>> cb = CbProtectionAPI()
     >>> query = cb.select(Computer)                     # returns a Query object matching all Computers
     >>> query = query.where("ipAddress:10.201.2.*")     # add a filter to this Query
     >>> query = query.sort("processorSpeed DESC")       # sort by computer processor speed, descending
@@ -108,7 +108,7 @@ class Query(PaginatedQuery):
         - You can chain where clauses together to create AND queries; only objects that match all ``where`` clauses
           will be returned.
 
-    .. _Enterprise Protection API reference:
+    .. _App Control REST API reference:
         https://developer.carbonblack.com/reference/enterprise-protection/8.0/rest-api/
     """
     def __init__(self, doc_class, cb, query=None):
@@ -134,11 +134,11 @@ class Query(PaginatedQuery):
     def where(self, q):
         """Add a filter to this query.
 
-        :param str q: Query string - see the `Enterprise Protection API reference`_.
+        :param str q: Query string - see the `App Control REST API reference`_.
         :return: Query object
         :rtype: :py:class:`Query`
 
-        .. _Enterprise Protection API reference:
+        .. _App Control REST API reference:
             https://developer.carbonblack.com/reference/enterprise-protection/8.0/rest-api/
         """
         nq = self._clone()
@@ -148,11 +148,11 @@ class Query(PaginatedQuery):
     def and_(self, q):
         """Add a filter to this query. Equivalent to calling :py:meth:`where` on this object.
 
-        :param str q: Query string - see the `Enterprise Protection API reference`_.
+        :param str q: Query string - see the `App Control REST API reference`_.
         :return: Query object
         :rtype: :py:class:`Query`
 
-        .. _Enterprise Protection API reference:
+        .. _App Control REST API reference:
             https://developer.carbonblack.com/reference/enterprise-protection/8.0/rest-api/
         """
         return self.where(q)
@@ -160,11 +160,11 @@ class Query(PaginatedQuery):
     def sort(self, new_sort):
         """Set the sort order for this query.
 
-        :param str new_sort: Sort order - see the `Enterprise Protection API reference`_.
+        :param str new_sort: Sort order - see the `App Control REST API reference`_.
         :return: Query object
         :rtype: :py:class:`Query`
 
-        .. _Enterprise Protection API reference:
+        .. _App Control REST API reference:
             https://developer.carbonblack.com/reference/enterprise-protection/8.0/rest-api/
         """
         new_sort = new_sort.strip()

--- a/src/cbapi/psc/defense/rest_api.py
+++ b/src/cbapi/psc/defense/rest_api.py
@@ -53,7 +53,7 @@ class Query(PaginatedQuery):
     """Represents a prepared query to the Cloud Endpoint Standard server.
 
     This object is returned as part of a :py:meth:`CbDefenseAPI.select`
-    operation on models requested from the Cloud Endpoint Standardserver. You should not have to create
+    operation on models requested from the Cloud Endpoint Standard server. You should not have to create
     this class yourself.
 
     The query is not executed on the server until it's accessed, either as an iterator (where it will generate values

--- a/src/cbapi/psc/defense/rest_api.py
+++ b/src/cbapi/psc/defense/rest_api.py
@@ -14,7 +14,7 @@ def convert_to_kv_pairs(q):
 
 
 class CbDefenseAPI(CbPSCBaseAPI):
-    """The main entry point into the Cb Defense API.
+    """The main entry point into the Carbon Black Cloud Endpoint Standard Defense API.
 
     :param str profile: (optional) Use the credentials in the named profile when connecting to the Carbon Black server.
         Uses the profile named 'default' when not specified.
@@ -31,8 +31,8 @@ class CbDefenseAPI(CbPSCBaseAPI):
         return Query(cls, self, query_string)
 
     def notification_listener(self, interval=60):
-        """Generator to continually poll the Cb Defense server for notifications (alerts). Note that this can only
-        be used with a 'SIEM' key generated in the Cb Defense console.
+        """Generator to continually poll the Cloud Endpoint Standard server for notifications (alerts). Note that
+        this can only be used with a 'SIEM' key generated in the Carbon Black Cloud console.
         """
         while True:
             for notification in self.get_notifications():
@@ -40,8 +40,8 @@ class CbDefenseAPI(CbPSCBaseAPI):
             time.sleep(interval)
 
     def get_notifications(self):
-        """Retrieve queued notifications (alerts) from the Cb Defense server. Note that this can only be used
-        with a 'SIEM' key generated in the Cb Defense console.
+        """Retrieve queued notifications (alerts) from the Cloud Endpoint Standard server. Note that this can only be
+        used with a 'SIEM' key generated in the Carbon Black Cloud console.
 
         :returns: list of dictionary objects representing the notifications, or an empty list if none available.
         """
@@ -50,10 +50,11 @@ class CbDefenseAPI(CbPSCBaseAPI):
 
 
 class Query(PaginatedQuery):
-    """Represents a prepared query to the Cb Defense server.
+    """Represents a prepared query to the Cloud Endpoint Standard server.
 
     This object is returned as part of a :py:meth:`CbDefenseAPI.select`
-    operation on models requested from the Cb Defense server. You should not have to create this class yourself.
+    operation on models requested from the Cloud Endpoint Standardserver. You should not have to create
+    this class yourself.
 
     The query is not executed on the server until it's accessed, either as an iterator (where it will generate values
     on demand as they're requested) or as a list (where it will retrieve the entire result set and save to a list).

--- a/src/cbapi/psc/threathunter/models.py
+++ b/src/cbapi/psc/threathunter/models.py
@@ -254,7 +254,7 @@ class Feed(FeedModel):
         self._reports = [Report(cb, initial_data=report, feed_id=feed_id) for report in reports]
 
     def save(self, public=False):
-        """Saves this feed on the ThreatHunter server.
+        """Saves this feed on the Enterprise EDR server.
 
         :param public:  Whether to make the feed publicly available
         :return: The saved feed
@@ -294,7 +294,7 @@ class Feed(FeedModel):
             report.validate()
 
     def delete(self):
-        """Deletes this feed from the ThreatHunter server.
+        """Deletes this feed from the Enterprise EDR server.
 
         :raise InvalidObjectError: if `id` is missing
         """
@@ -501,7 +501,7 @@ class Report(FeedModel):
         return self
 
     def delete(self):
-        """Deletes this report from the ThreatHunter server.
+        """Deletes this report from the Enterprise EDR server.
 
         >>> report.delete()
 
@@ -822,7 +822,7 @@ class Watchlist(FeedModel):
                                         force_init=False, full_doc=True)
 
     def save(self):
-        """Saves this watchlist on the ThreatHunter server.
+        """Saves this watchlist on the Enterprise EDR server.
 
         :return: The saved watchlist
         :rtype: :py:class:`Watchlist`
@@ -888,7 +888,7 @@ class Watchlist(FeedModel):
         return (classifier_dict["key"], classifier_dict["value"])
 
     def delete(self):
-        """Deletes this watchlist from the ThreatHunter server.
+        """Deletes this watchlist from the Enterprise EDR server.
 
         :raise InvalidObjectError: if `id` is missing
         """

--- a/src/cbapi/psc/threathunter/query.py
+++ b/src/cbapi/psc/threathunter/query.py
@@ -12,8 +12,8 @@ log = logging.getLogger(__name__)
 
 class QueryBuilder(object):
     """
-    Provides a flexible interface for building prepared queries for the CB
-    ThreatHunter backend.
+    Provides a flexible interface for building prepared queries for the Carbon Black
+    Enterprise EDR backend.
 
     This object can be instantiated directly, or can be managed implicitly
     through the :py:meth:`CbThreatHunterAPI.select` API.
@@ -157,10 +157,10 @@ class QueryBuilder(object):
 
 
 class Query(PaginatedQuery):
-    """Represents a prepared query to the Cb ThreatHunter backend.
+    """Represents a prepared query to the Carbon Black Enterprise EDR backend.
 
     This object is returned as part of a :py:meth:`CbThreatHunterPI.select`
-    operation on models requested from the Cb ThreatHunter backend. You should not have to create this class yourself.
+    operation on models requested from the Enterprise EDR backend. You should not have to create this class yourself.
 
     The query is not executed on the server until it's accessed, either as an iterator (where it will generate values
     on demand as they're requested) or as a list (where it will retrieve the entire result set and save to a list).

--- a/src/cbapi/psc/threathunter/rest_api.py
+++ b/src/cbapi/psc/threathunter/rest_api.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 class CbThreatHunterAPI(CbPSCBaseAPI):
-    """The main entry point into the Carbon Black Cloud ThreatHunter API.
+    """The main entry point into the Carbon Black Cloud Enterprise EDR API.
 
     :param str profile: (optional) Use the credentials in the named profile when connecting to the Carbon Black server.
         Uses the profile named 'default' when not specified.
@@ -60,7 +60,7 @@ class CbThreatHunterAPI(CbPSCBaseAPI):
         return resp.get("valid", False)
 
     def convert_query(self, query):
-        """Converts a legacy CB Response query to a ThreatHunter query.
+        """Converts a legacy Carbon Black EDR query to an Enterprise EDR query.
 
         :param str query: the query to convert
         :return: the converted query
@@ -87,7 +87,7 @@ class CbThreatHunterAPI(CbPSCBaseAPI):
 
     def queries(self):
         """Retrieves a list of queries, active or complete, known by
-        the ThreatHunter server.
+        the Enterprise EDR server.
 
         :return: a list of query ids
         :rtype: list(str)

--- a/src/cbapi/response/models.py
+++ b/src/cbapi/response/models.py
@@ -679,21 +679,21 @@ class Sensor(MutableBaseModel):
     @property
     def registration_time(self):
         """
-        Returns the time the sensor registered with the Cb Response Server
+        Returns the time the sensor registered with the EDR Server
         """
         return convert_from_cb(getattr(self, 'registration_time', -1))
 
     @property
     def sid(self):
         """
-        Security Identifier being used by the Cb Response Sensor
+        Security Identifier being used by the EDR Sensor
         """
         return getattr(self, 'computer_sid')
 
     @property
     def webui_link(self):
         """
-        Returns the Cb Response Web UI link associated with this Sensor
+        Returns the Carbon Black EDR Web UI link associated with this Sensor
         """
         return '{0:s}/#/host/{1}'.format(self._cb.url, self._model_unique_id)
 
@@ -701,7 +701,7 @@ class Sensor(MutableBaseModel):
     @property
     def queued_stats(self):
         """
-        Returns a list of status and size of the queued event logs from the associated Cb Response Sensor
+        Returns a list of status and size of the queued event logs from the associated EDR Sensor
 
         :example:
 
@@ -720,14 +720,14 @@ class Sensor(MutableBaseModel):
     @property
     def activity_stats(self):
         """
-        Returns a list of activity statistics from the associated Cb Response Sensor
+        Returns a list of activity statistics from the associated EDR Sensor
         """
         return self._cb.get_object("{0}/activity".format(self._build_api_request_uri()), default=[])
 
     @property
     def resource_status(self):
         """
-        Returns a list of memory statistics used by the Cb Response Sensor
+        Returns a list of memory statistics used by the EDR Sensor
         """
         return self._cb.get_object("{0}/resourcestatus".format(self._build_api_request_uri()), default=[])
 
@@ -747,9 +747,9 @@ class Sensor(MutableBaseModel):
 
     def flush_events(self):
         """
-        Performs a flush of events for this Cb Response Sensor
+        Performs a flush of events for this EDR Sensor
 
-        :warning: This may cause a significant amount of network traffic from this sensor to the Cb Response Server
+        :warning: This may cause a significant amount of network traffic from this sensor to the EDR Server
         """
 
         # Note that Cb Response 6 requires the date/time stamp to be sent in RFC822 format (not ISO 8601).
@@ -761,7 +761,7 @@ class Sensor(MutableBaseModel):
         """
         Restarts the Carbon Black sensor (*not* the underlying endpoint operating system).
 
-        This simply sets the flag to ask the sensor to restart the next time it checks into the Cb Response server,
+        This simply sets the flag to ask the sensor to restart the next time it checks into the EDR server,
         it does not wait for the sensor to restart.
         """
         self.restart_queued = True
@@ -769,7 +769,7 @@ class Sensor(MutableBaseModel):
 
     def isolate(self, timeout=None):
         """
-        Turn on network isolation for this Cb Response Sensor.
+        Turn on network isolation for this EDR Sensor.
 
         This function will block and only return when the isolation is complete, or if a timeout is reached. By default,
         there is no timeout. You can specify a timeout period (in seconds) in the "timeout" parameter to this
@@ -794,7 +794,7 @@ class Sensor(MutableBaseModel):
 
     def unisolate(self, timeout=None):
         """
-        Turn off network isolation for this Cb Response Sensor.
+        Turn off network isolation for this EDR Sensor.
 
         This function will block and only return when the isolation is removed, or if a timeout is reached. By default,
         there is no timeout. You can specify a timeout period (in seconds) in the "timeout" parameter to this
@@ -1433,8 +1433,8 @@ class ProcessQuery(WatchlistEnabledQuery):
         """Set the group-by field name for this query. Typically, you will want to set this to 'id' if you only want
         one result per process.
 
-        This method is only available for Cb Response servers 6.0 and above. Calling this on a Query object connected
-        to a Cb Response 5.x server will simply result in a no-op.
+        This method is only available for EDR servers 6.0 and above. Calling this on a Query object connected
+        to a EDR 5.x server will simply result in a no-op.
 
         :param str field_name: Field name to group the result set by.
         :return: Query object
@@ -1451,8 +1451,8 @@ class ProcessQuery(WatchlistEnabledQuery):
     def max_children(self, num_children):
         """Sets the number of children to fetch with the process
 
-        This method is only available for Cb Response servers 6.0 and above. Calling this on a Query object connected
-        to a Cb Response 5.x server will simply result in a no-op.
+        This method is only available for EDR servers 6.0 and above. Calling this on a Query object connected
+        to a EDR 5.x server will simply result in a no-op.
 
         :default: 15
         :param int num_children: Number of children to fetch with process
@@ -1482,8 +1482,8 @@ class ProcessQuery(WatchlistEnabledQuery):
 
         This option will limit the number of Solr cores that need to be searched for events that match the query.
 
-        This method is only available for Cb Response servers 6.0 and above. Calling this on a Query object connected
-        to a Cb Response 5.x server will simply result in a no-op.
+        This method is only available for EDR servers 6.0 and above. Calling this on a Query object connected
+        to a EDR 5.x server will simply result in a no-op.
 
         :param str v: Timestamp (either string or datetime object).
         :return: Query object
@@ -1508,8 +1508,8 @@ class ProcessQuery(WatchlistEnabledQuery):
 
         This option will limit the number of Solr cores that need to be searched for events that match the query.
 
-        This method is only available for Cb Response servers 6.0 and above. Calling this on a Query object connected
-        to a Cb Response 5.x server will simply result in a no-op.
+        This method is only available for EDR servers 6.0 and above. Calling this on a Query object connected
+        to a EDR 5.x server will simply result in a no-op.
 
         :param str v: Timestamp (either string or datetime object).
         :return: Query object
@@ -1534,8 +1534,8 @@ class ProcessQuery(WatchlistEnabledQuery):
 
         This option will limit the number of Solr cores that need to be searched for events that match the query.
 
-        This method is only available for Cb Response servers 6.0 and above. Calling this on a Query object connected
-        to a Cb Response 5.x server will simply result in a no-op.
+        This method is only available for EDR servers 6.0 and above. Calling this on a Query object connected
+        to a EDR 5.x server will simply result in a no-op.
 
         :param str v: Timestamp (either string or datetime object).
         :return: Query object
@@ -1560,8 +1560,8 @@ class ProcessQuery(WatchlistEnabledQuery):
 
         This option will limit the number of Solr cores that need to be searched for events that match the query.
 
-        This method is only available for Cb Response servers 6.0 and above. Calling this on a Query object connected
-        to a Cb Response 5.x server will simply result in a no-op.
+        This method is only available for EDR servers 6.0 and above. Calling this on a Query object connected
+        to a EDR 5.x server will simply result in a no-op.
 
         :param str v: Timestamp (either string or datetime object).
         :return: Query object
@@ -1672,7 +1672,7 @@ class Binary(TaggedModel):
     @property
     def webui_link(self):
         """
-        Returns the Cb Response Web UI link associated with this Binary object
+        Returns the Carbon Black EDR Web UI link associated with this Binary object
         """
         return '{0:s}/#binary/{1:s}'.format(self._cb.url, self.md5sum)
 
@@ -1861,7 +1861,7 @@ class Binary(TaggedModel):
     @property
     def banned(self):
         """
-        Returns *BannedHash* object if this Binary's hash has been whitelisted (Banned), otherwise returns *False*
+        Returns *BannedHash* object if this Binary's hash has been banned, otherwise returns *False*
         """
         try:
             bh = self._cb.select(BannedHash, self.md5sum.lower())
@@ -2429,7 +2429,7 @@ class Process(TaggedModel):
     @property
     def parent_md5(self):
         """
-        Workaround since parent_md5 silently disappeared in ~Cb Response 6.x
+        Workaround since parent_md5 silently disappeared in EDR 6.x
         """
         return self.parent.process_md5
 
@@ -2752,7 +2752,7 @@ class Process(TaggedModel):
     @property
     def comms_ip(self):
         """
-        Returns ascii representation of the ip address used to communicate with the Cb Response Server
+        Returns ascii representation of the ip address used to communicate with the EDR Server
         """
         try:
             ip_address = socket.inet_ntoa(struct.pack('>i', self._attribute('comms_ip', 0)))
@@ -2764,7 +2764,7 @@ class Process(TaggedModel):
     @property
     def interface_ip(self):
         """
-        Returns ascii representation of the ip address of the interface used to communicate with the Cb Response server.
+        Returns ascii representation of the ip address of the interface used to communicate with the EDR server.
         If using NAT, this will be the "internal" IP address of the sensor.
         """
         try:
@@ -2843,7 +2843,7 @@ class Process(TaggedModel):
     @property
     def webui_link(self):
         """
-        Returns the Cb Response Web UI link associated with this process
+        Returns the Carbon Black EDR Web UI link associated with this process
         """
         if not self.suppressed_process:
             return '%s/#analyze/%s/%s' % (self._cb.url, self.id, self.current_segment)

--- a/src/cbapi/response/query.py
+++ b/src/cbapi/response/query.py
@@ -11,11 +11,11 @@ log = logging.getLogger(__name__)
 
 
 class Query(PaginatedQuery):
-    """Represents a prepared query to the Carbon Black Enterprise Response server.
+    """Represents a prepared query to the Carbon Black EDR server.
 
-    This object is returned as part of a :py:meth:`CbEnterpriseResponseAPI.select`
+    This object is returned as part of a :py:meth:`CbResponseAPI.select`
     operation on Process and Binary objects from the Carbon Black
-    Enterprise Response server. You should not have to create this class yourself.
+    EDR server. You should not have to create this class yourself.
 
     The query is not executed on the server until it's accessed, either as an iterator (where it will generate values
     on demand as they're requested) or as a list (where it will retrieve the entire result set and save to a list).
@@ -28,7 +28,7 @@ class Query(PaginatedQuery):
 
     Examples::
 
-    >>> cb = CbEnterpriseResponseAPI()
+    >>> cb = CbResponseAPI()
     >>> query = cb.select(Process)                      # returns a Query object matching all Processes
     >>> query = query.where("process_name:notepad.exe") # add a filter to this Query
     >>> query = query.sort("last_update desc")          # sort by last update time, most recent first

--- a/src/cbapi/response/rest_api.py
+++ b/src/cbapi/response/rest_api.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 class CbResponseAPI(BaseAPI):
-    """The main entry point into the Carbon Black Enterprise Response API.
+    """The main entry point into the Carbon Black EDR API.
     Note that calling this will automatically connect to the Carbon Black server in order to verify
     connectivity and get the server version.
 
@@ -30,8 +30,8 @@ class CbResponseAPI(BaseAPI):
 
     Usage::
 
-    >>> from cbapi import CbEnterpriseResponseAPI
-    >>> cb = CbEnterpriseResponseAPI(profile="production")
+    >>> from cbapi import CbResponseAPI
+    >>> cb = CbResponseAPI(profile="production")
     """
     def __init__(self, *args, **kwargs):
         timeout = kwargs.pop("timeout", 120)   # set default timeout period to two minutes, 2x the default nginx timeout
@@ -66,7 +66,7 @@ class CbResponseAPI(BaseAPI):
         return self._lr_scheduler
 
     def info(self):
-        """Retrieve basic version information from the Carbon Black Enterprise Response server.
+        """Retrieve basic version information from the Carbon Black DER server.
 
         :return: Dictionary with information retrieved from the ``/api/info`` API route
         :rtype: dict
@@ -75,7 +75,7 @@ class CbResponseAPI(BaseAPI):
         return r.json()
 
     def dashboard_statistics(self):
-        """Retrieve dashboard statistics from the Carbon Black Enterprise Response server.
+        """Retrieve dashboard statistics from the Carbon Black EDR server.
 
         :return: Dictionary with information retrieved from the ``/api/v1/dashboard/statistics`` API route
         :rtype: dict
@@ -84,7 +84,7 @@ class CbResponseAPI(BaseAPI):
         return r.json()
 
     def license_request(self):
-        """Retrieve license request block from the Carbon Black Enterprise Response server.
+        """Retrieve license request block from the Carbon Black EDR server.
 
         :return: License request block
         :rtype: str
@@ -93,7 +93,7 @@ class CbResponseAPI(BaseAPI):
         return r.json().get("license_request_block", "")
 
     def update_license(self, license_block):
-        """Upload new license to the Carbon Black Enterprise Response server.
+        """Upload new license to the Carbon Black EDR server.
 
         :param str license_block: Licence block provided by Carbon Black support
         :raises ServerError: if the license is not accepted by the Carbon Black server
@@ -108,14 +108,13 @@ class CbResponseAPI(BaseAPI):
             return Query(cls, self, **kwargs)
 
     def from_ui(self, uri):
-        """Retrieve a Carbon Black Enterprise Response object based on URL from the Carbon Black Enterprise Response
-        web user interface.
+        """Retrieve a Carbon Black EDR object based on URL from the Carbon Black EDR web user interface.
 
         For example, calling this function with
         ``https://server/#/analyze/00000001-0000-0554-01d1-3bc4553b8c9f/1`` as the ``uri`` argument will return a new
         :py:class: cbapi.response.models.Process class initialized with the process GUID from the URL.
 
-        :param str uri: Web browser URL from the Cb web interface
+        :param str uri: Web browser URL from the CB web interface
         :return: the appropriate model object for the URL provided
         :raises ApiError: if the URL does not correspond to a recognized model object
         """
@@ -166,7 +165,7 @@ class CbResponseAPI(BaseAPI):
         return self.live_response.request_session(sensor_id)
 
     def create_new_partition(self):
-        """Create a new Solr time partition for event storage. Available in Cb Response 6.1 and above.
+        """Create a new Solr time partition for event storage. Available in Carbon Black EDR 6.1 and above.
         This will force roll-over current hot partition into warm partition (by renaming it to a time-stamped name)
         and create a new hot partition ("writer").
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [x Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been added that prove the fix is effective or that the feature works.
- [ ] New and existing tests pass locally with the changes.
- [x] Code follows the style guidelines of this project (PEP8, clean code).
- [ ] Linter has passed locally and any fixes were made for failures.
- [x] A self-review of the code has been done.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes (not tied to bugs/features)
- [ ] Other (please describe):


## What is the ticket or issue number?
<!-- Please link to a jira ticket or relevant issue. -->

- Ticket Number: https://jira.carbonblack.local/browse/CBAPI-1821

- Issue Number: N/A

## Pull Request Description
<!-- Please describe the behavior or changes that are being added by this PR. If this is a bug fix please describe the current behavior as well -->
Update documentation for CBAPI to change names of products in text and also eliminate certain terminology.  Changes made:
* Cb Protection -> VMware Carbon Black App Control
* Cb Response -> VMware Carbon Black EDR
* Cb Defense -> VMware Carbon Black Cloud Endpoint Standard
* Cb ThreatHunter -> VMware Carbon Black Cloud Enterprise EDR
* Cb LiveOps -> VMware Carbon Black Cloud Audit and Remediation

Note that this does _not_ change names of Python classes or packages for backward compatibility.  So classes still exist like CbProtectionAPI, CbResponseAPI, CbDefenseAPI, CbThreatHunterAPI, etc.

Also, one instance of "whitelist" was removed because it was redundant in that context. Note that certain appearances of "blacklist" are part of URLs used in examples and hence cannot be changed until the actual URLs are.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Text (post-compilation) has been checked with grep/fgrep for terms still needing to be changed.  Since only docstrings and RST documentation files are changed, no code behavior will be altered.

## Other information:

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
