### PR TITLE
CB-38082: Fix order for paginated sensor search

### DIFF
--- a/src/cbapi/response/models.py
+++ b/src/cbapi/response/models.py
@@ -590,6 +590,8 @@ class SensorPaginatedQuery(PaginatedQuery):
         else:
             args = {}
 
+        args.update({"sort.col":"computer_name", "sort.dir":"asc"})
+
         args['start'] = start
 
         if rows:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
<!-- These checkboxes can be checked like this: [x] no spaces between the brackets and the x!-->
- [ x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ x] Tests have been added that prove the fix is effective or that the feature works.
- [ x] New and existing tests pass locally with the changes.
- [x ] Code follows the style guidelines of this project (PEP8, clean code).
- [x ] Linter has passed locally and any fixes were made for failures.
- [ x] A self-review of the code has been done.

## Pull request type

Bugfix/issue

Please check the type of change your PR introduces:
- [+ ] Bugfix

## What is the ticket or issue number?
cb-38082

- Ticket Number: N/A

- Issue Number: 
- https://github.com/carbonblack/cbapi-python/issues/301

## Pull Request Description
One line change to change the sort order for EDR sensor searches from 'last_checkin_time' (default when none provided explicitly) to 'hostname' to make the sort stable as sensors checkin during paging

## Does this introduce a breaking change?

- [ ] Yes
- [+ ] No


## How Has This Been Tested?
Manual testing

`from cbapi.response import CbResponseAPI, Sensor
import logging
logging.basicConfig(level=logging.DEBUG)

cb=CbResponseAPI()
cb_sensors = cb.select(Sensor).all()
sensors = list(cb_sensors)
`

## Other information:
[
](https://github.com/carbonblack/cbapi-python/issues/301)